### PR TITLE
Move State Machine into CardViewModel.kt...

### DIFF
--- a/app/src/main/java/com/example/flashcards/controller/viewModels/CardViewModel.kt
+++ b/app/src/main/java/com/example/flashcards/controller/viewModels/CardViewModel.kt
@@ -1,7 +1,10 @@
 package com.example.flashcards.controller.viewModels
 
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.flashcards.model.CardState
 import com.example.flashcards.model.CardUiState
 import com.example.flashcards.model.tablesAndApplication.Card
 import com.example.flashcards.model.repositories.FlashCardRepository
@@ -22,6 +25,14 @@ class CardViewModel(private val flashCardRepository: FlashCardRepository) : View
 
     private val errorMessage = MutableStateFlow<String?>(null)
 
+    private val cardState: MutableState<CardState> = mutableStateOf(CardState.Idle)
+
+    fun transitionTo(newState: CardState) {
+        cardState.value = newState
+    }
+
+    fun getState(): CardState = cardState.value
+
 
     companion object {
         private const val TIMEOUT_MILLIS = 4_000L
@@ -38,15 +49,18 @@ class CardViewModel(private val flashCardRepository: FlashCardRepository) : View
         return withContext(Dispatchers.IO) {
             try{
                 cardTypeViewModel.getDueTypesForDeck(deckId)
-                getCards(deckId)
-                delay(120)
+                //getCards(deckId)
+                delay(50)
+                transitionTo(CardState.Finished)
                 false
             }
             catch (e : Exception){
+                println(e)
                 true
             }
         }
     }
+    /* IN CASE WE NEED IT AGAIN
     fun getCards(deckId: Int){
         try {
             viewModelScope.launch {
@@ -63,7 +77,7 @@ class CardViewModel(private val flashCardRepository: FlashCardRepository) : View
             println(e)
         }
     }
-
+    */
     fun getDeckWithCards(deckId: Int, cardTypeViewModel: CardTypeViewModel) {
         cardTypeViewModel.getAllTypesForDeck(deckId)
         getAllCards(deckId)

--- a/app/src/main/java/com/example/flashcards/model/Migration.kt
+++ b/app/src/main/java/com/example/flashcards/model/Migration.kt
@@ -3,7 +3,6 @@ package com.example.flashcards.model
 import android.util.Log
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
-import java.util.Date
 
 val MIGRATION_3_5 = object : Migration(3, 5) {
     override fun migrate(database: SupportSQLiteDatabase) {
@@ -67,10 +66,10 @@ val MIGRATION_6_7 = object : Migration(6,7){
             database.execSQL("PRAGMA foreign_keys=ON;")
 
             // Add 'createdOn' column to the 'decks' table
-            database.execSQL("ALTER TABLE decks ADD COLUMN createdOn INTEGER NOT NULL DEFAULT ${Date().time}")
+            database.execSQL("ALTER TABLE decks ADD COLUMN createdOn INTEGER NOT NULL DEFAULT ${System.currentTimeMillis()}")
 
             // Add 'createdOn' column to the 'cards' table
-            database.execSQL("ALTER TABLE cards ADD COLUMN createdOn INTEGER NOT NULL DEFAULT ${Date().time}")
+            database.execSQL("ALTER TABLE cards ADD COLUMN createdOn INTEGER NOT NULL DEFAULT ${System.currentTimeMillis()}")
             database.setTransactionSuccessful()
         } catch (e: Exception) {
             // Log the error for debugging

--- a/app/src/main/java/com/example/flashcards/model/UiStates.kt
+++ b/app/src/main/java/com/example/flashcards/model/UiStates.kt
@@ -41,14 +41,4 @@ sealed class CardState {
     //data class Error(val message: String) : CardState()
 }
 
-class CardStateMachine {
-    private var state: CardState = CardState.Idle
-
-    fun transitionTo(newState: CardState) {
-        // Add validation logic for valid transitions if needed
-        state = newState
-    }
-
-    fun getState(): CardState = state
-}
 

--- a/app/src/main/java/com/example/flashcards/views/cardViews/editCardViews/EditingCardView.kt
+++ b/app/src/main/java/com/example/flashcards/views/cardViews/editCardViews/EditingCardView.kt
@@ -127,7 +127,6 @@ class EditingCardView(
                                         delayNavigate()
                                         onNavigateBack()
                                     } else {
-                                        println("settings error message.")
                                         cardTypeViewModel.setErrorMessage(fillOutfields)
                                     }
                                 }


### PR DESCRIPTION
,Bug Fix to CreatedOn, Refactor CardDeckView.kt for optimization and bug UI fixes and more clean code. No need for the constant view.model.getDueCardCards or for two seperate UI states when AllCardTypes has the Card entity and the CardTypes Entities

## Summary by Sourcery

Refactor the card deck view to improve performance and fix UI bugs. Update the card update logic and simplify the view model state management.

Bug Fixes:
- Fix an issue with the card creation timestamp.

Enhancements:
- Optimize card deck view for better performance and cleaner code.