### PR TITLE
Allow changing cardAmount for decks

### DIFF
--- a/app/schemas/com.example.flashcards.model.FlashCardDatabase/17.json
+++ b/app/schemas/com.example.flashcards.model.FlashCardDatabase/17.json
@@ -1,0 +1,514 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 17,
+    "identityHash": "e33bcfbea0f7903e85d430623d57b350",
+    "entities": [
+      {
+        "tableName": "decks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `uuid` TEXT NOT NULL, `reviewAmount` INTEGER NOT NULL, `goodMultiplier` REAL NOT NULL, `badMultiplier` REAL NOT NULL, `createdOn` INTEGER NOT NULL, `cardAmount` INTEGER NOT NULL, `nextReview` INTEGER NOT NULL, `cardsLeft` INTEGER NOT NULL, `lastUpdated` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reviewAmount",
+            "columnName": "reviewAmount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "goodMultiplier",
+            "columnName": "goodMultiplier",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "badMultiplier",
+            "columnName": "badMultiplier",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdOn",
+            "columnName": "createdOn",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cardAmount",
+            "columnName": "cardAmount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextReview",
+            "columnName": "nextReview",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cardsLeft",
+            "columnName": "cardsLeft",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_decks_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_decks_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "cards",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `deckId` INTEGER NOT NULL, `deckUUID` TEXT NOT NULL, `reviewsLeft` INTEGER NOT NULL, `nextReview` INTEGER NOT NULL, `passes` INTEGER NOT NULL, `prevSuccess` INTEGER NOT NULL, `totalPasses` INTEGER NOT NULL, `type` TEXT NOT NULL, `createdOn` INTEGER NOT NULL, `partOfList` INTEGER NOT NULL, FOREIGN KEY(`deckId`) REFERENCES `decks`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deckId",
+            "columnName": "deckId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deckUUID",
+            "columnName": "deckUUID",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reviewsLeft",
+            "columnName": "reviewsLeft",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextReview",
+            "columnName": "nextReview",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "passes",
+            "columnName": "passes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prevSuccess",
+            "columnName": "prevSuccess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPasses",
+            "columnName": "totalPasses",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdOn",
+            "columnName": "createdOn",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "partOfList",
+            "columnName": "partOfList",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_cards_deckId",
+            "unique": false,
+            "columnNames": [
+              "deckId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cards_deckId` ON `${TABLE_NAME}` (`deckId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "decks",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "deckId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "basicCard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cardId` INTEGER NOT NULL, `question` TEXT NOT NULL, `answer` TEXT NOT NULL, PRIMARY KEY(`cardId`), FOREIGN KEY(`cardId`) REFERENCES `cards`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "cardId",
+            "columnName": "cardId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "question",
+            "columnName": "question",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "answer",
+            "columnName": "answer",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "cardId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_basicCard_cardId",
+            "unique": false,
+            "columnNames": [
+              "cardId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_basicCard_cardId` ON `${TABLE_NAME}` (`cardId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "cards",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "cardId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "threeFieldCard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cardId` INTEGER NOT NULL, `question` TEXT NOT NULL, `middle` TEXT NOT NULL, `answer` TEXT NOT NULL, PRIMARY KEY(`cardId`), FOREIGN KEY(`cardId`) REFERENCES `cards`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "cardId",
+            "columnName": "cardId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "question",
+            "columnName": "question",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "middle",
+            "columnName": "middle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "answer",
+            "columnName": "answer",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "cardId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_threeFieldCard_cardId",
+            "unique": false,
+            "columnNames": [
+              "cardId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_threeFieldCard_cardId` ON `${TABLE_NAME}` (`cardId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "cards",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "cardId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "hintCard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cardId` INTEGER NOT NULL, `question` TEXT NOT NULL, `hint` TEXT NOT NULL, `answer` TEXT NOT NULL, PRIMARY KEY(`cardId`), FOREIGN KEY(`cardId`) REFERENCES `cards`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "cardId",
+            "columnName": "cardId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "question",
+            "columnName": "question",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hint",
+            "columnName": "hint",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "answer",
+            "columnName": "answer",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "cardId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_hintCard_cardId",
+            "unique": false,
+            "columnNames": [
+              "cardId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_hintCard_cardId` ON `${TABLE_NAME}` (`cardId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "cards",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "cardId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "multiChoiceCard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cardId` INTEGER NOT NULL, `question` TEXT NOT NULL, `choiceA` TEXT NOT NULL, `choiceB` TEXT NOT NULL, `choiceC` TEXT NOT NULL, `choiceD` TEXT NOT NULL, `correct` INTEGER NOT NULL, PRIMARY KEY(`cardId`), FOREIGN KEY(`cardId`) REFERENCES `cards`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "cardId",
+            "columnName": "cardId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "question",
+            "columnName": "question",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "choiceA",
+            "columnName": "choiceA",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "choiceB",
+            "columnName": "choiceB",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "choiceC",
+            "columnName": "choiceC",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "choiceD",
+            "columnName": "choiceD",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correct",
+            "columnName": "correct",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "cardId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_multiChoiceCard_cardId",
+            "unique": false,
+            "columnNames": [
+              "cardId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_multiChoiceCard_cardId` ON `${TABLE_NAME}` (`cardId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "cards",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "cardId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "savedCards",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `reviewsLeft` INTEGER NOT NULL, `nextReview` INTEGER NOT NULL, `passes` INTEGER NOT NULL, `prevSuccess` INTEGER NOT NULL, `totalPasses` INTEGER NOT NULL, `partOfList` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reviewsLeft",
+            "columnName": "reviewsLeft",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextReview",
+            "columnName": "nextReview",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "passes",
+            "columnName": "passes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prevSuccess",
+            "columnName": "prevSuccess",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPasses",
+            "columnName": "totalPasses",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "partOfList",
+            "columnName": "partOfList",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e33bcfbea0f7903e85d430623d57b350')"
+    ]
+  }
+}

--- a/app/src/main/java/com/example/flashcards/controller/AppViewModelProvider.kt
+++ b/app/src/main/java/com/example/flashcards/controller/AppViewModelProvider.kt
@@ -42,7 +42,7 @@ object AppViewModelProvider {
         initializer {
             AddCardViewModel(
                 flashCardApplication().container.flashCardRepository,
-                flashCardApplication().container.cardTypeRepository
+                flashCardApplication().container.cardTypeRepository,
             )
         }
         initializer {

--- a/app/src/main/java/com/example/flashcards/controller/onClickActions/DeckOnClickActions.kt
+++ b/app/src/main/java/com/example/flashcards/controller/onClickActions/DeckOnClickActions.kt
@@ -25,6 +25,45 @@ import com.example.flashcards.ui.theme.GetModifier
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
+fun updateCardAmount(
+    vm: EditDeckViewModel, newCA: Int,
+    errorMessage: MutableState<String>,
+    isSubmitting: MutableState<Boolean>, deck: Deck,
+    successful : MutableState<String>,
+    errorMessages: List<String>, successMessage: String,
+    coroutineScope: CoroutineScope
+){
+    coroutineScope.launch{
+        if (newCA < 5){
+            errorMessage.value = errorMessages[0]
+            return@launch
+        }
+        if (newCA > 1000){
+            errorMessage.value = errorMessages[1]
+            return@launch
+        }
+        if (newCA == deck.cardAmount){
+            errorMessage.value = errorMessages[2]
+            return@launch
+        }
+        isSubmitting.value = true
+        try {
+            val result = vm.updateDeckCardAmount(newCA, deck.id)
+            if (result > 0 ){
+                successful.value = successMessage
+            } else {
+                errorMessage.value =
+                    errorMessages[3]
+            }
+        } catch (e : Exception){
+            errorMessage.value =
+                e.message ?: R.string.error_occurred.toString()
+        }
+        finally {
+            isSubmitting.value = false
+        }
+    }
+}
 fun updateReviewAmount(
     vm: EditDeckViewModel, newRA : Int,
     errorMessage: MutableState<String>,
@@ -33,7 +72,6 @@ fun updateReviewAmount(
     errorMessages : List<String>, successMessage : String,
     coroutineScope: CoroutineScope
 ) {
-
     coroutineScope.launch {
         if (newRA <= 0) {
             errorMessage.value = errorMessages[0]

--- a/app/src/main/java/com/example/flashcards/controller/viewModels/cardViewsModels/AddCardViewModel.kt
+++ b/app/src/main/java/com/example/flashcards/controller/viewModels/cardViewsModels/AddCardViewModel.kt
@@ -1,6 +1,12 @@
 package com.example.flashcards.controller.viewModels.cardViewsModels
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.example.flashcards.model.repositories.CardTypeRepository
 import com.example.flashcards.model.repositories.FlashCardRepository
@@ -17,9 +23,9 @@ import java.util.Date
 
 class AddCardViewModel(
     private val flashCardRepository: FlashCardRepository,
-    private val cardTypeRepository: CardTypeRepository
+    private val cardTypeRepository: CardTypeRepository,
 ) : ViewModel() {
-    private val privateErrorMessage : MutableStateFlow<String> = MutableStateFlow("")
+    private val privateErrorMessage: MutableStateFlow<String> = MutableStateFlow("")
     val errorMessage = privateErrorMessage.asStateFlow()
     fun addBasicCard(deck: Deck, question: String, answer: String) {
         if (question.isNotEmpty() && answer.isNotEmpty()) {
@@ -46,6 +52,7 @@ class AddCardViewModel(
             }
         }
     }
+
     fun addHintCard(
         deck: Deck, question: String,
         hint: String, answer: String
@@ -113,14 +120,15 @@ class AddCardViewModel(
     fun addMultiChoiceCard(
         deck: Deck,
         question: String,
-        choiceA : String,
-        choiceB : String,
-        choiceC : String,
-        choiceD : String,
-        correct : Char
+        choiceA: String,
+        choiceB: String,
+        choiceC: String,
+        choiceD: String,
+        correct: Char
     ) {
         if (question.isNotEmpty() && choiceA.isNotEmpty() &&
-            choiceB.isNotEmpty() && correct in 'a'..'d') {
+            choiceB.isNotEmpty() && correct in 'a'..'d'
+        ) {
             viewModelScope.launch {
                 val cardId = flashCardRepository.insertCard(
                     Card(

--- a/app/src/main/java/com/example/flashcards/controller/viewModels/cardViewsModels/CardDeckViewModel.kt
+++ b/app/src/main/java/com/example/flashcards/controller/viewModels/cardViewsModels/CardDeckViewModel.kt
@@ -113,7 +113,7 @@ class CardDeckViewModel(
                             Log.d("GetDueCardTypes", "collected = false")
                             withTimeout(EXTRA_TIME) {
                                 cardTypeRepository.getDueAllCardTypes(
-                                    deck.id, deck.cardAmount
+                                    deck.id, deck.cardsLeft
                                 ).map { allCards ->
                                     updateUiState(allCards)
                                 }.collect { state ->
@@ -248,9 +248,7 @@ class CardDeckViewModel(
                             createdOn = card.createdOn,
                             partOfList = false,
                         )
-                        if (card.reviewsLeft <= 1) {
                             deck.cardsLeft -= 1
-                        }
                         viewModelScope.launch {
                             flashCardRepository.updateCard(newCard)
                         }
@@ -294,7 +292,6 @@ class CardDeckViewModel(
         return withContext(Dispatchers.IO) {
             try {
                 getDueTypesForDeck(deck)
-                //getCards(deckId)
                 clearErrorMessage()
             } catch (e: Exception) {
                 handleError(e, "Something went wrong")

--- a/app/src/main/java/com/example/flashcards/controller/viewModels/deckViewsModels/AddDeckViewModel.kt
+++ b/app/src/main/java/com/example/flashcards/controller/viewModels/deckViewsModels/AddDeckViewModel.kt
@@ -57,6 +57,7 @@ class AddDeckViewModel(
                             name = name,
                             reviewAmount = reviewAmount,
                             nextReview = Date(),
+                            lastUpdated = Date()
                         )
                     )
                 } catch (e: SQLiteConstraintException) {

--- a/app/src/main/java/com/example/flashcards/controller/viewModels/deckViewsModels/EditDeckViewModel.kt
+++ b/app/src/main/java/com/example/flashcards/controller/viewModels/deckViewsModels/EditDeckViewModel.kt
@@ -31,6 +31,8 @@ class EditDeckViewModel(
         private set
     var deckRA by mutableStateOf(savedStateHandle["deckRA"] ?: "")
         private set
+    var deckCA by mutableStateOf(savedStateHandle["deckCA"]?: "")
+        private set
     var deckIA by mutableStateOf(savedStateHandle.get<Boolean>("deckIsActive"))
         private set
 
@@ -59,6 +61,10 @@ class EditDeckViewModel(
         savedStateHandle["deckRA"] = reviewAmount
     }
 
+    fun updateCAField(cardAmount: String){
+        deckCA = cardAmount
+        savedStateHandle["deckCA"] = cardAmount
+    }
 
     suspend fun checkIfDeckExists(deckName: String): Int {
         return withContext(Dispatchers.IO) {
@@ -153,6 +159,26 @@ class EditDeckViewModel(
                     handleError(e.message.toString())
                 } catch (e: Exception) {
                     handleError("Error updating deck Review Amount: ${e.message}")
+                }
+            }
+        }
+        return 0
+    }
+
+    suspend fun updateDeckCardAmount(cardAmount : Int, deckId: Int): Int {
+        if (cardAmount > 4 && cardAmount < 1001) {
+            return withContext(Dispatchers.IO) {
+                try {
+                    val row =
+                        flashCardRepository.updateCardAmount(cardAmount, deckId)
+                    if (row == 0) {
+                        handleError("Failed to update cardAmount")
+                    }
+                    row
+                } catch (e: SQLiteConstraintException) {
+                    handleError(e.message.toString())
+                } catch (e: Exception) {
+                    handleError("Error updating deck cardAmount: ${e.message}")
                 }
             }
         }

--- a/app/src/main/java/com/example/flashcards/controller/viewModels/deckViewsModels/MainViewModel.kt
+++ b/app/src/main/java/com/example/flashcards/controller/viewModels/deckViewsModels/MainViewModel.kt
@@ -19,7 +19,6 @@ import com.example.flashcards.model.uiModels.CardUpdateError
 import com.example.flashcards.model.uiModels.SavedCardUiState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.withContext
@@ -68,10 +67,12 @@ class MainViewModel(
         savedStateHandle["appStarted"] = true
     }
 
-    fun getDeckById(
+    suspend fun getDeckById(
         deckId: Int,
-    ): Flow<Deck?> {
-        return flashCardRepository.getDeckStream(deckId)
+    ): Deck {
+        return withContext(Dispatchers.IO) {
+            flashCardRepository.getDeckStream(deckId)
+        }
     }
 
     suspend fun performDatabaseUpdate() {
@@ -124,9 +125,9 @@ class MainViewModel(
         }
     }
 
-    suspend fun resetCardList(){
-        return withContext(Dispatchers.IO){
-            viewModelScope.launch(Dispatchers.IO){
+    suspend fun resetCardList() {
+        return withContext(Dispatchers.IO) {
+            viewModelScope.launch(Dispatchers.IO) {
                 flashCardRepository.resetCardLefts()
             }
         }

--- a/app/src/main/java/com/example/flashcards/model/FlashCardDatabase.kt
+++ b/app/src/main/java/com/example/flashcards/model/FlashCardDatabase.kt
@@ -6,20 +6,21 @@ import androidx.room.Database
 import androidx.room.Room
 import androidx.room.TypeConverters
 import androidx.sqlite.db.SupportSQLiteDatabase
-import com.example.flashcards.model.daoFiles.BasicCardDao
-import com.example.flashcards.model.daoFiles.CardDao
-import com.example.flashcards.model.daoFiles.CardTypesDao
-import com.example.flashcards.model.daoFiles.DeckDao
-import com.example.flashcards.model.daoFiles.HintCardDao
-import com.example.flashcards.model.daoFiles.MultiChoiceCardDao
-import com.example.flashcards.model.daoFiles.SavedCardDao
-import com.example.flashcards.model.daoFiles.ThreeCardDao
+import com.example.flashcards.model.daoFiles.allCardTypesDao.BasicCardDao
+import com.example.flashcards.model.daoFiles.deckAndCardDao.CardDao
+import com.example.flashcards.model.daoFiles.deckAndCardDao.CardTypesDao
+import com.example.flashcards.model.daoFiles.deckAndCardDao.DeckDao
+import com.example.flashcards.model.daoFiles.allCardTypesDao.HintCardDao
+import com.example.flashcards.model.daoFiles.allCardTypesDao.MultiChoiceCardDao
+import com.example.flashcards.model.daoFiles.deckAndCardDao.SavedCardDao
+import com.example.flashcards.model.daoFiles.allCardTypesDao.ThreeCardDao
 import com.example.flashcards.model.migrations.MIGRATION_10_11
 import com.example.flashcards.model.migrations.MIGRATION_11_12
 import com.example.flashcards.model.migrations.MIGRATION_12_13
 import com.example.flashcards.model.migrations.MIGRATION_13_14
 import com.example.flashcards.model.migrations.MIGRATION_14_15
 import com.example.flashcards.model.migrations.MIGRATION_15_16
+import com.example.flashcards.model.migrations.MIGRATION_16_17
 import com.example.flashcards.model.migrations.MIGRATION_3_5
 import com.example.flashcards.model.migrations.MIGRATION_5_6
 import com.example.flashcards.model.migrations.MIGRATION_6_7
@@ -32,7 +33,7 @@ import com.example.flashcards.model.tablesAndApplication.HintCard
 import com.example.flashcards.model.tablesAndApplication.ThreeFieldCard
 import com.example.flashcards.model.tablesAndApplication.Deck
 import com.example.flashcards.model.tablesAndApplication.MultiChoiceCard
-import com.example.flashcards.model.tablesAndApplication.NonNullConverter
+import com.example.flashcards.model.tablesAndApplication.TimeConverter
 import com.example.flashcards.model.tablesAndApplication.SavedCard
 import kotlinx.coroutines.CoroutineScope
 
@@ -48,9 +49,9 @@ import java.util.Calendar
         ThreeFieldCard::class,
         HintCard::class,
         MultiChoiceCard::class,
-        SavedCard::class], version = 16
+        SavedCard::class], version = 17
 )
-@TypeConverters(NonNullConverter::class)
+@TypeConverters(TimeConverter::class)
 abstract class FlashCardDatabase : RoomDatabase() {
     abstract fun deckDao(): DeckDao
     abstract fun cardDao(): CardDao
@@ -82,7 +83,8 @@ abstract class FlashCardDatabase : RoomDatabase() {
                             MIGRATION_12_13,
                             MIGRATION_13_14,
                             MIGRATION_14_15,
-                            MIGRATION_15_16
+                            MIGRATION_15_16,
+                            MIGRATION_16_17
                         )
                         .fallbackToDestructiveMigration()
                         .addCallback(FlashCardDatabaseCallback(scope))
@@ -127,13 +129,15 @@ abstract class FlashCardDatabase : RoomDatabase() {
             val historyDeck = Deck(
                 name = "History",
                 nextReview = nextReviewDate,
-                cardsLeft = 20
+                cardsLeft = 20,
+                lastUpdated = nextReviewDate
             )
             deckDao.insertDeck(historyDeck)
             val motorcycleDeck = Deck(
                 name = "Motorcycle Written Exam",
                 nextReview = nextReviewDate,
-                cardsLeft = 20
+                cardsLeft = 20,
+                lastUpdated = nextReviewDate
             )
             deckDao.insertDeck(motorcycleDeck)
 

--- a/app/src/main/java/com/example/flashcards/model/daoFiles/allCardTypesDao/BasicCardDao.kt
+++ b/app/src/main/java/com/example/flashcards/model/daoFiles/allCardTypesDao/BasicCardDao.kt
@@ -1,4 +1,4 @@
-package com.example.flashcards.model.daoFiles
+package com.example.flashcards.model.daoFiles.allCardTypesDao
 
 
 import androidx.room.Dao

--- a/app/src/main/java/com/example/flashcards/model/daoFiles/allCardTypesDao/HintCardDao.kt
+++ b/app/src/main/java/com/example/flashcards/model/daoFiles/allCardTypesDao/HintCardDao.kt
@@ -1,4 +1,4 @@
-package com.example.flashcards.model.daoFiles
+package com.example.flashcards.model.daoFiles.allCardTypesDao
 
 import androidx.room.Dao
 import androidx.room.Insert

--- a/app/src/main/java/com/example/flashcards/model/daoFiles/allCardTypesDao/MultiChoiceCardDao.kt
+++ b/app/src/main/java/com/example/flashcards/model/daoFiles/allCardTypesDao/MultiChoiceCardDao.kt
@@ -1,4 +1,4 @@
-package com.example.flashcards.model.daoFiles
+package com.example.flashcards.model.daoFiles.allCardTypesDao
 
 import androidx.room.Dao
 import androidx.room.Insert

--- a/app/src/main/java/com/example/flashcards/model/daoFiles/allCardTypesDao/ThreeCardDao.kt
+++ b/app/src/main/java/com/example/flashcards/model/daoFiles/allCardTypesDao/ThreeCardDao.kt
@@ -1,4 +1,4 @@
-package com.example.flashcards.model.daoFiles
+package com.example.flashcards.model.daoFiles.allCardTypesDao
 
 import androidx.room.Dao
 import androidx.room.Insert

--- a/app/src/main/java/com/example/flashcards/model/daoFiles/deckAndCardDao/CardDao.kt
+++ b/app/src/main/java/com/example/flashcards/model/daoFiles/deckAndCardDao/CardDao.kt
@@ -1,4 +1,4 @@
-package com.example.flashcards.model.daoFiles
+package com.example.flashcards.model.daoFiles.deckAndCardDao
 
 import androidx.room.Dao
 import androidx.room.Insert

--- a/app/src/main/java/com/example/flashcards/model/daoFiles/deckAndCardDao/CardTypesDao.kt
+++ b/app/src/main/java/com/example/flashcards/model/daoFiles/deckAndCardDao/CardTypesDao.kt
@@ -1,4 +1,4 @@
-package com.example.flashcards.model.daoFiles
+package com.example.flashcards.model.daoFiles.deckAndCardDao
 
 import androidx.room.Dao
 import androidx.room.Query
@@ -35,7 +35,7 @@ interface CardTypesDao {
     @Transaction
     @Query(
         """SELECT * FROM cards WHERE deckId = :deckId
-        ORDER BY cards.nextReview"""
+        ORDER BY cards.id"""
     )
     fun getAllCardTypes(deckId: Int):
             Flow<List<AllCardTypes>>

--- a/app/src/main/java/com/example/flashcards/model/daoFiles/deckAndCardDao/SavedCardDao.kt
+++ b/app/src/main/java/com/example/flashcards/model/daoFiles/deckAndCardDao/SavedCardDao.kt
@@ -1,4 +1,4 @@
-package com.example.flashcards.model.daoFiles
+package com.example.flashcards.model.daoFiles.deckAndCardDao
 
 import androidx.room.Dao
 import androidx.room.Insert

--- a/app/src/main/java/com/example/flashcards/model/migrations/MIGRATION_10_11.kt
+++ b/app/src/main/java/com/example/flashcards/model/migrations/MIGRATION_10_11.kt
@@ -4,6 +4,9 @@ import android.util.Log
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
+/**
+ * Creating a savedCards table
+ * */
 val MIGRATION_10_11 = object : Migration(10, 11) {
     override fun migrate(database: SupportSQLiteDatabase) {
         database.beginTransaction()

--- a/app/src/main/java/com/example/flashcards/model/migrations/MIGRATION_11_12.kt
+++ b/app/src/main/java/com/example/flashcards/model/migrations/MIGRATION_11_12.kt
@@ -3,12 +3,11 @@ package com.example.flashcards.model.migrations
 import android.util.Log
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
-import java.util.UUID
 
 
-
-
-
+/**
+ * Changing primary keys of cardTypes
+ * */
 
 val MIGRATION_11_12 = object : Migration(11, 12) {
     override fun migrate(database: SupportSQLiteDatabase) {

--- a/app/src/main/java/com/example/flashcards/model/migrations/MIGRATION_13_14.kt
+++ b/app/src/main/java/com/example/flashcards/model/migrations/MIGRATION_13_14.kt
@@ -4,6 +4,11 @@ import android.util.Log
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
+/**
+ * Adding a nextReview to decks
+ * Adding a partOfList to cards and savedCards
+ * */
+
 val MIGRATION_13_14 = object : Migration(13, 14) {
     override fun migrate(database: SupportSQLiteDatabase) {
         database.beginTransaction()

--- a/app/src/main/java/com/example/flashcards/model/migrations/MIGRATION_14_15.kt
+++ b/app/src/main/java/com/example/flashcards/model/migrations/MIGRATION_14_15.kt
@@ -4,6 +4,11 @@ import android.util.Log
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
+/**
+ * Refactoring the primary key of cardTypes back into the old version
+ * where the primary key was the cardId
+ * */
+
 val MIGRATION_14_15 = object : Migration(14, 15)  {
     override fun migrate(database: SupportSQLiteDatabase) {
         database.beginTransaction()

--- a/app/src/main/java/com/example/flashcards/model/migrations/MIGRATION_15_16.kt
+++ b/app/src/main/java/com/example/flashcards/model/migrations/MIGRATION_15_16.kt
@@ -4,6 +4,10 @@ import android.util.Log
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
+/**
+ * Adding a cardsLeft column to deck
+ * */
+
 val MIGRATION_15_16 = object : Migration(15, 16) {
     override fun migrate(database: SupportSQLiteDatabase) {
         database.beginTransaction()

--- a/app/src/main/java/com/example/flashcards/model/migrations/MIGRATION_16_17.kt
+++ b/app/src/main/java/com/example/flashcards/model/migrations/MIGRATION_16_17.kt
@@ -5,28 +5,26 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
 /**
- * Adding a cardAmount to decks
+ * Adding a lastUpdated Column to decks
  * */
 
-val MIGRATION_12_13 = object : Migration(12, 13) {
+val MIGRATION_16_17 = object : Migration(16, 17)  {
     override fun migrate(database: SupportSQLiteDatabase) {
         database.beginTransaction()
         try {
+            database.execSQL("PRAGMA foreign_keys=OFF;")
+            // Add 'createdOn' column to the 'decks' table
+            database.execSQL("""ALTER TABLE decks ADD COLUMN lastUpdated 
+                INTEGER NOT NULL DEFAULT ${System.currentTimeMillis()}""")
+
             database.execSQL("PRAGMA foreign_keys=ON;")
-            // Add 'cardAmount' column to the 'decks' table
-            database.execSQL("""
-                ALTER TABLE decks
-                ADD COLUMN cardAmount 
-                INTEGER NOT NULL DEFAULT 20
-                """)
             database.setTransactionSuccessful()
         } catch (e: Exception) {
             // Log the error for debugging
-            Log.e("Migration", "Migration 12 to 13 failed", e)
-            throw RuntimeException("Migration 12 to 13 failed: ${e.message}")
+            Log.e("Migration", "Migration 16 to 17 failed", e)
+            throw RuntimeException("Migration 16 to 17 failed: ${e.message}")
         } finally {
             database.endTransaction()
         }
     }
 }
-

--- a/app/src/main/java/com/example/flashcards/model/migrations/MIGRATION_3_5.kt
+++ b/app/src/main/java/com/example/flashcards/model/migrations/MIGRATION_3_5.kt
@@ -4,6 +4,9 @@ import android.util.Log
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
+/**
+ * Adding a Multiplier
+ * */
 val MIGRATION_3_5 = object : Migration(3, 5) {
     override fun migrate(database: SupportSQLiteDatabase) {
         database.beginTransaction()

--- a/app/src/main/java/com/example/flashcards/model/migrations/MIGRATION_5_6.kt
+++ b/app/src/main/java/com/example/flashcards/model/migrations/MIGRATION_5_6.kt
@@ -4,6 +4,10 @@ import android.util.Log
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
+/**
+ * Updated Multipliers
+ * */
+
 val MIGRATION_5_6 = object : Migration(5, 6) {
     override fun migrate(database: SupportSQLiteDatabase) {
         database.beginTransaction()

--- a/app/src/main/java/com/example/flashcards/model/migrations/MIGRATION_6_7.kt
+++ b/app/src/main/java/com/example/flashcards/model/migrations/MIGRATION_6_7.kt
@@ -4,6 +4,10 @@ import android.util.Log
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
+/**
+ * Adding a createdOn
+ * */
+
 val MIGRATION_6_7 = object : Migration(6, 7) {
     override fun migrate(database: SupportSQLiteDatabase) {
         database.beginTransaction()
@@ -11,10 +15,12 @@ val MIGRATION_6_7 = object : Migration(6, 7) {
             database.execSQL("PRAGMA foreign_keys=ON;")
 
             // Add 'createdOn' column to the 'decks' table
-            database.execSQL("ALTER TABLE decks ADD COLUMN createdOn INTEGER NOT NULL DEFAULT ${System.currentTimeMillis()}")
+            database.execSQL("""ALTER TABLE decks ADD COLUMN createdOn 
+                INTEGER NOT NULL DEFAULT ${System.currentTimeMillis()}""")
 
             // Add 'createdOn' column to the 'cards' table
-            database.execSQL("ALTER TABLE cards ADD COLUMN createdOn INTEGER NOT NULL DEFAULT ${System.currentTimeMillis()}")
+            database.execSQL("""ALTER TABLE cards ADD COLUMN createdOn 
+                INTEGER NOT NULL DEFAULT ${System.currentTimeMillis()}""")
             database.setTransactionSuccessful()
         } catch (e: Exception) {
             // Log the error for debugging

--- a/app/src/main/java/com/example/flashcards/model/migrations/MIGRATION_7_8.kt
+++ b/app/src/main/java/com/example/flashcards/model/migrations/MIGRATION_7_8.kt
@@ -4,6 +4,9 @@ import android.util.Log
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
+/**
+ * Adding a MultiChoiceCard
+ * */
 val MIGRATION_7_8 = object : Migration(7, 8) {
     override fun migrate(database: SupportSQLiteDatabase) {
         database.beginTransaction()

--- a/app/src/main/java/com/example/flashcards/model/migrations/MIGRATION_8_9.kt
+++ b/app/src/main/java/com/example/flashcards/model/migrations/MIGRATION_8_9.kt
@@ -4,6 +4,9 @@ import android.util.Log
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
+/**
+ * Creating an Index for cards on deckId
+ * */
 val MIGRATION_8_9 = object : Migration(8, 9) {
     override fun migrate(database: SupportSQLiteDatabase) {
         database.beginTransaction()

--- a/app/src/main/java/com/example/flashcards/model/migrations/MIGRATION_9_10.kt
+++ b/app/src/main/java/com/example/flashcards/model/migrations/MIGRATION_9_10.kt
@@ -4,7 +4,10 @@ import android.util.Log
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import java.util.UUID
-
+/**
+ * Adding a UUID to decks and a foreign key to the deck UUID
+ * to each card
+ * */
 val MIGRATION_9_10 = object : Migration(9, 10) {
     override fun migrate(database: SupportSQLiteDatabase) {
         database.beginTransaction()

--- a/app/src/main/java/com/example/flashcards/model/repositories/FlashCardRepository.kt
+++ b/app/src/main/java/com/example/flashcards/model/repositories/FlashCardRepository.kt
@@ -22,9 +22,11 @@ interface FlashCardRepository {
 
     fun updateCardReviewAmount(newReviewAmount : Int, deckId: Int): Int
 
+    fun updateCardAmount(cardAmount : Int, deckId: Int) : Int
+
     fun getAllDecksStream(): Flow<List<Deck>>
 
-    fun getDeckStream(id: Int): Flow<Deck>
+    fun getDeckStream(id: Int): Deck
 
     fun getCardCount(): Flow<List<Int>>
 
@@ -72,4 +74,6 @@ interface FlashCardRepository {
     suspend fun becomePartOfList(id: Int)
 
     fun updateCardsLeft(deckId: Int, cardsLeft : Int)
+
+
 }

--- a/app/src/main/java/com/example/flashcards/model/repositories/OfflineCardTypeRepository.kt
+++ b/app/src/main/java/com/example/flashcards/model/repositories/OfflineCardTypeRepository.kt
@@ -1,12 +1,12 @@
 package com.example.flashcards.model.repositories
 
-import com.example.flashcards.model.daoFiles.BasicCardDao
+import com.example.flashcards.model.daoFiles.allCardTypesDao.BasicCardDao
 import com.example.flashcards.model.tablesAndApplication.BasicCard
 import com.example.flashcards.model.tablesAndApplication.ThreeFieldCard
-import com.example.flashcards.model.daoFiles.CardTypesDao
-import com.example.flashcards.model.daoFiles.HintCardDao
-import com.example.flashcards.model.daoFiles.MultiChoiceCardDao
-import com.example.flashcards.model.daoFiles.ThreeCardDao
+import com.example.flashcards.model.daoFiles.deckAndCardDao.CardTypesDao
+import com.example.flashcards.model.daoFiles.allCardTypesDao.HintCardDao
+import com.example.flashcards.model.daoFiles.allCardTypesDao.MultiChoiceCardDao
+import com.example.flashcards.model.daoFiles.allCardTypesDao.ThreeCardDao
 import com.example.flashcards.model.tablesAndApplication.HintCard
 import com.example.flashcards.model.tablesAndApplication.MultiChoiceCard
 import com.example.flashcards.model.tablesAndApplication.MultiChoiceCardType

--- a/app/src/main/java/com/example/flashcards/model/repositories/OfflineFlashCardRepository.kt
+++ b/app/src/main/java/com/example/flashcards/model/repositories/OfflineFlashCardRepository.kt
@@ -3,9 +3,9 @@ package com.example.flashcards.model.repositories
 import com.example.flashcards.model.tablesAndApplication.Card
 import com.example.flashcards.model.tablesAndApplication.DeckWithCards
 import com.example.flashcards.model.tablesAndApplication.Deck
-import com.example.flashcards.model.daoFiles.CardDao
-import com.example.flashcards.model.daoFiles.DeckDao
-import com.example.flashcards.model.daoFiles.SavedCardDao
+import com.example.flashcards.model.daoFiles.deckAndCardDao.CardDao
+import com.example.flashcards.model.daoFiles.deckAndCardDao.DeckDao
+import com.example.flashcards.model.daoFiles.deckAndCardDao.SavedCardDao
 import com.example.flashcards.model.tablesAndApplication.SavedCard
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
@@ -84,6 +84,12 @@ class OfflineFlashCardRepository(
             throw (e)
         }
 
+    override fun updateCardAmount(cardAmount: Int, deckId: Int) =
+        try {
+            deckDao.updateCardAmount(cardAmount, deckId)
+        } catch(e : Exception){
+            throw (e)
+        }
     override suspend fun insertCard(card: Card) = cardDao.insertCard(card)
 
     override suspend fun updateCard(card: Card) = cardDao.updateCard(card)

--- a/app/src/main/java/com/example/flashcards/model/uiModels/Preferences.kt
+++ b/app/src/main/java/com/example/flashcards/model/uiModels/Preferences.kt
@@ -1,15 +1,9 @@
 package com.example.flashcards.model.uiModels
 
 import android.content.Context
-import android.os.Bundle
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 
-class CreatedBundle(private val savedStateHandle: Bundle?){
-    fun getSavedHandle():Bundle?{
-        return savedStateHandle
-    }
-}
 
 class PreferencesManager(
     context: Context,

--- a/app/src/main/java/com/example/flashcards/views/cardViews/editCardViews/EditingCardView.kt
+++ b/app/src/main/java/com/example/flashcards/views/cardViews/editCardViews/EditingCardView.kt
@@ -40,7 +40,6 @@ import com.example.flashcards.model.uiModels.Fields
 import com.example.flashcards.model.tablesAndApplication.Card
 import com.example.flashcards.ui.theme.GetModifier
 import com.example.flashcards.views.miscFunctions.DeleteCardButton
-import com.example.flashcards.views.miscFunctions.delayNavigate
 import kotlinx.coroutines.launch
 
 class EditingCardView(
@@ -75,8 +74,8 @@ class EditingCardView(
                     modifier = Modifier.fillMaxSize()) {
                     Text(
                         text = stringResource(R.string.edit_flashcard),
-                        fontSize = 35.sp,
-                        lineHeight = 40.sp,
+                        fontSize = 25.sp,
+                        lineHeight = 30.sp,
                         textAlign = TextAlign.Center,
                         color = getModifier.titleColor(),
                         modifier = getModifier.editCardModifier()
@@ -133,10 +132,7 @@ class EditingCardView(
                     ) {
                         Button(
                             onClick = {
-                                coroutineScope.launch {
-                                    delayNavigate()
                                     onNavigateBack()
-                                }
                             },
                             modifier = Modifier.weight(1f),
                             colors = ButtonDefaults.buttonColors(

--- a/app/src/main/java/com/example/flashcards/views/cardViews/editCardViews/EditingCardsList.kt
+++ b/app/src/main/java/com/example/flashcards/views/cardViews/editCardViews/EditingCardsList.kt
@@ -1,6 +1,7 @@
 package com.example.flashcards.views.cardViews.editCardViews
 
 import android.annotation.SuppressLint
+import android.util.Log
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -47,7 +48,6 @@ class EditCardsList(
     fun ViewFlashCards(
         deck: Deck, onNavigate: () -> Unit, goToEditCard: () -> Unit
     ) {
-
         //var deckWithCards by remember { mutableStateOf(DeckWithCards(Deck(0, loading.toString() ), emptyList())) }
         val cardListUiState by editingCardListVM.cardListUiState.collectAsState()
         val middleCard = rememberSaveable { mutableIntStateOf(0) }
@@ -112,11 +112,8 @@ class EditCardsList(
     }
 
     private suspend fun getListState(listState: LazyListState, middleCard: Int) {
-        if (listState.firstVisibleItemScrollOffset == 0 &&
-            fields.scrollPosition.value == 0
-        ) {
-            listState.scrollToItem(0)
-        } else if (fields.scrollPosition.value == 0) {
+        if (fields.scrollPosition.value == 0) {
+            Log.d("scrollPosition", "${fields.scrollPosition.value}")
             listState.scrollToItem(0)
         } else if (listState.firstVisibleItemScrollOffset == 0 &&
             fields.scrollPosition.value > 0

--- a/app/src/main/java/com/example/flashcards/views/miscFunctions/Buttons.kt
+++ b/app/src/main/java/com/example/flashcards/views/miscFunctions/Buttons.kt
@@ -90,13 +90,9 @@ fun BackButton(
     modifier: Modifier = Modifier,
     getModifier: GetModifier
 ) {
-    val coroutineScope = rememberCoroutineScope()
     IconButton(
         onClick = {
-            coroutineScope.launch {
-                delayNavigate()
-                onBackClick()
-            }
+            onBackClick()
         },
         modifier = modifier
             .background(
@@ -198,14 +194,11 @@ fun MainSettingsButton(
     getModifier: GetModifier,
     fields: Fields
 ) {
-    val coroutineScope = rememberCoroutineScope()
     IconButton(
         onClick = {
-            coroutineScope.launch {
-                if (!fields.mainClicked.value) {
-                    fields.mainClicked.value = true
-                    onNavigateToSettings()
-                }
+            if (!fields.mainClicked.value) {
+                fields.mainClicked.value = true
+                onNavigateToSettings()
             }
         },
         modifier = modifier

--- a/app/src/main/java/com/example/flashcards/views/miscFunctions/DeckDetails.kt
+++ b/app/src/main/java/com/example/flashcards/views/miscFunctions/DeckDetails.kt
@@ -18,6 +18,7 @@ fun setDeckFields(
     vm.updateRAField(deck.reviewAmount.toString())
     vm.updateBMField(deck.badMultiplier)
     vm.updateGMField(deck.goodMultiplier)
+    vm.updateCAField(deck.cardAmount.toString())
     vm.updateActivity()
 }
 
@@ -27,6 +28,7 @@ fun createDeckDetails(deck: Deck) : DeckDetails{
     dD.value.gm.value = deck.goodMultiplier.toString()
     dD.value.bm.value = deck.badMultiplier.toString()
     dD.value.ra.value = deck.reviewAmount.toString()
+    dD.value.ca.value = deck.cardAmount.toString()
     return dD.value
 }
 fun retrieveDeckDetails(vm : EditDeckViewModel) : DeckDetails{
@@ -35,6 +37,7 @@ fun retrieveDeckDetails(vm : EditDeckViewModel) : DeckDetails{
     dD.value.gm.value = vm.deckGM.toString()
     dD.value.bm.value = vm.deckBM.toString()
     dD.value.ra.value = vm.deckRA
+    dD.value.ca.value = vm.deckCA
     return dD.value
 }
 
@@ -42,5 +45,6 @@ data class DeckDetails(
     val name : MutableState<String> = mutableStateOf(""),
     val gm : MutableState<String> = mutableStateOf(""),
     val bm : MutableState<String> = mutableStateOf(""),
-    val ra : MutableState<String> = mutableStateOf("")
+    val ra : MutableState<String> = mutableStateOf(""),
+    val ca : MutableState<String> = mutableStateOf("")
 )

--- a/app/src/main/java/com/example/flashcards/views/miscFunctions/Functions.kt
+++ b/app/src/main/java/com/example/flashcards/views/miscFunctions/Functions.kt
@@ -372,6 +372,15 @@ fun returnDeckError(): List<String> {
 }
 
 @Composable
+fun returnCardAmountError() : List<String>{
+    return listOf(
+        "daily card Amount must be at least 5",
+        "only 1000 cards a day are allowed",
+        "card amount is the same",
+        "failed to update card amount")
+}
+
+@Composable
 fun getSavableFields(fields: Fields): Fields {
     return Fields(
         question = rememberSaveable { mutableStateOf("") },

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -69,4 +69,5 @@
     <string name="sure_to_delete_card">Estas seguro/a que quiere borrar esta carta?</string>
     <string name="reviews_left">Revisiones restantes de la carta: </string>
     <string name="default_value">Predeterminado:</string>
+    <string name="updated_card_amount">Cantidad de tarjetas actualizadas!</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,4 +69,5 @@
     <string name="sure_to_delete_card">Are you sure you want to delete this card?</string>
     <string name="reviews_left">Card reviews left: </string>
     <string name="default_value">Default:</string>
+    <string name="updated_card_amount">updated card amount!</string>
 </resources>


### PR DESCRIPTION
Update Nav Controller to only get deck ONCE (very important for speed and navigation)
Allow users to change cardAmount for a deck, from 5 cards up to 1000 cards.
Fix On create application to not update the database since they are a new user.

## Summary by Sourcery

New Features:
- Allow users to change the number of cards they review daily for each deck.