### PR TITLE
Allow user to change CardType

### DIFF
--- a/app/src/main/java/com/example/flashcards/controller/cardHandlers/CardTypeHandler.kt
+++ b/app/src/main/java/com/example/flashcards/controller/cardHandlers/CardTypeHandler.kt
@@ -1,8 +1,11 @@
 package com.example.flashcards.controller.cardHandlers
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import com.example.flashcards.model.tablesAndApplication.CT
-import com.example.flashcards.model.tablesAndApplication.CT.Basic
 import com.example.flashcards.model.uiModels.Fields
 import com.example.flashcards.views.cardViews.editCardViews.EditBasicCard
 import com.example.flashcards.views.cardViews.editCardViews.EditHintCard
@@ -10,6 +13,10 @@ import com.example.flashcards.views.cardViews.editCardViews.EditThreeCard
 import com.example.flashcards.ui.theme.GetModifier
 import com.example.flashcards.views.cardViews.editCardViews.EditChoiceCard
 import com.example.flashcards.views.cardViews.editCardViews.EditMathCard
+import com.example.flashcards.views.miscFunctions.createBasicCardDetails
+import com.example.flashcards.views.miscFunctions.createChoiceCardDetails
+import com.example.flashcards.views.miscFunctions.createMathCardDetails
+import com.example.flashcards.views.miscFunctions.createThreeOrHintCardDetails
 
 interface CardTypeHandler {
     @Composable
@@ -17,6 +24,7 @@ interface CardTypeHandler {
         cardId: Int,
         fields: Fields,
         ct : CT,
+        changed : Boolean,
         getModifier: GetModifier
     )
 }
@@ -27,10 +35,31 @@ class BasicCardTypeHandler : CardTypeHandler {
         cardId: Int,
         fields: Fields,
         ct : CT,
+        changed : Boolean,
         getModifier: GetModifier
     ) {
-        if (ct is Basic) {
-            EditBasicCard(ct.basicCard, fields)
+
+        if (ct is CT.Basic) {
+            if (!changed) {
+                val cardDetails by remember {
+                    mutableStateOf(
+                        createBasicCardDetails(ct.basicCard)
+                    )
+                }
+                fields.question = rememberSaveable { mutableStateOf(cardDetails.question.value) }
+                fields.answer = rememberSaveable { mutableStateOf(cardDetails.answer.value) }
+            }
+            EditBasicCard(fields)
+        } else {
+            if (ct is CT.ThreeField) {
+                EditBasicCard(fields)
+            } else if (ct is CT.Hint) {
+                EditBasicCard(fields)
+            } else if (ct is CT.MultiChoice) {
+                EditBasicCard(fields)
+            } else if (ct is CT.Math) {
+                EditBasicCard(fields)
+            }
         }
     }
 }
@@ -41,10 +70,38 @@ class ThreeCardTypeHandler : CardTypeHandler {
         cardId: Int,
         fields: Fields,
         ct : CT,
+        changed : Boolean,
         getModifier: GetModifier
     ) {
         if (ct is CT.ThreeField){
-            EditThreeCard(ct.threeFieldCard, fields)
+            if (!changed) {
+                val cardDetails by remember {
+                    mutableStateOf(
+                        createThreeOrHintCardDetails(
+                            ct.threeFieldCard.question,
+                            ct.threeFieldCard.middle,
+                            ct.threeFieldCard.answer
+                        )
+                    )
+                }
+                fields.question = rememberSaveable {
+                    mutableStateOf(cardDetails.question.value) }
+                fields.middleField = rememberSaveable {
+                    mutableStateOf(cardDetails.middleField.value) }
+                fields.answer = rememberSaveable {
+                    mutableStateOf(cardDetails.answer.value) }
+            }
+            EditThreeCard(fields)
+        } else {
+            if (ct is CT.Basic) {
+                EditThreeCard(fields)
+            } else if (ct is CT.Hint) {
+                EditThreeCard(fields)
+            } else if (ct is CT.MultiChoice) {
+                EditThreeCard(fields)
+            } else if (ct is CT.Math) {
+                EditThreeCard(fields)
+            }
         }
     }
 }
@@ -55,10 +112,36 @@ class HintCardTypeHandler : CardTypeHandler {
         cardId: Int,
         fields: Fields,
         ct : CT,
+        changed : Boolean,
         getModifier: GetModifier
     ) {
-        if (ct is CT.Hint){
-            EditHintCard(ct.hintCard, fields)
+        if (ct is CT.Hint) {
+            if (!changed){
+                val cardDetails by remember {
+                    mutableStateOf(
+                        createThreeOrHintCardDetails(
+                            ct.hintCard.question, ct.hintCard.hint, ct.hintCard.answer
+                        )
+                    )
+                }
+                fields.question = rememberSaveable {
+                    mutableStateOf(cardDetails.question.value) }
+                fields.middleField = rememberSaveable {
+                    mutableStateOf(cardDetails.middleField.value) }
+                fields.answer = rememberSaveable {
+                    mutableStateOf(cardDetails.answer.value) }
+            }
+            EditHintCard(fields)
+        } else {
+            if (ct is CT.Basic) {
+                EditHintCard(fields)
+            } else if (ct is CT.ThreeField) {
+                EditHintCard(fields)
+            } else if (ct is CT.MultiChoice) {
+                EditHintCard(fields)
+            } else if (ct is CT.Math) {
+                EditHintCard(fields)
+            }
         }
     }
 }
@@ -69,10 +152,38 @@ class ChoiceCardTypeHandler : CardTypeHandler {
         cardId: Int,
         fields: Fields,
         ct : CT,
+        changed : Boolean,
         getModifier: GetModifier
     ) {
-        if (ct is CT.MultiChoice){
-            EditChoiceCard(ct.multiChoiceCard, fields, getModifier)
+        if (ct is CT.MultiChoice) {
+            if (!changed){
+                val cardDetails by remember {
+                    mutableStateOf(
+                        createChoiceCardDetails(ct.multiChoiceCard)
+                    )
+                }
+                fields.question = rememberSaveable { mutableStateOf(cardDetails.question.value) }
+                fields.choices[0] = rememberSaveable {
+                    mutableStateOf(cardDetails.choices[0].value) }
+                fields.choices[1] = rememberSaveable {
+                    mutableStateOf(cardDetails.choices[1].value) }
+                fields.choices[2] = rememberSaveable {
+                    mutableStateOf(cardDetails.choices[2].value) }
+                fields.choices[3] = rememberSaveable {
+                    mutableStateOf(cardDetails.choices[3].value) }
+                fields.correct = rememberSaveable { mutableStateOf(cardDetails.correct.value) }
+            }
+            EditChoiceCard(fields, getModifier)
+        } else {
+            if (ct is CT.Basic) {
+                EditChoiceCard(fields, getModifier)
+            } else if (ct is CT.ThreeField) {
+                EditChoiceCard(fields, getModifier)
+            } else if (ct is CT.Hint) {
+                EditChoiceCard(fields, getModifier)
+            } else if (ct is CT.Math) {
+                EditChoiceCard(fields, getModifier)
+            }
         }
     }
 }
@@ -83,15 +194,86 @@ class MathCardTypeHandler : CardTypeHandler {
         cardId: Int,
         fields: Fields,
         ct: CT,
+        changed : Boolean,
         getModifier: GetModifier
     ) {
         if (ct is CT.Math){
-            EditMathCard(ct.mathCard, fields, getModifier)
+            if (!changed){
+                val cardDetails by remember {
+                    mutableStateOf(
+                        createMathCardDetails(
+                            ct.mathCard.question,
+                            ct.mathCard.steps,
+                            ct.mathCard.answer
+                        )
+                    )
+                }
+                fields.question = rememberSaveable { mutableStateOf(cardDetails.question.value) }
+                fields.stringList = rememberSaveable { cardDetails.stringList }
+                fields.answer = rememberSaveable { mutableStateOf(cardDetails.answer.value) }
+            }
+            EditMathCard(fields, getModifier)
+        } else {
+            if (ct is CT.Basic) {
+                EditMathCard(fields, getModifier)
+            } else if (ct is CT.ThreeField) {
+                EditMathCard(fields, getModifier)
+            } else if (ct is CT.Hint) {
+                EditMathCard(fields, getModifier)
+            } else if (ct is CT.MultiChoice) {
+                EditMathCard(fields, getModifier)
+            }
         }
     }
 }
 
-
+fun returnCardTypeHandler(newType : String, currentType : String) : CardTypeHandler? {
+    return if (newType == currentType) {
+        when (currentType) {
+            "basic" -> {
+                BasicCardTypeHandler()
+            }
+            "three" -> {
+                ThreeCardTypeHandler()
+            }
+            "hint" -> {
+                HintCardTypeHandler()
+            }
+            "multi" -> {
+                ChoiceCardTypeHandler()
+            }
+            "math" -> {
+                MathCardTypeHandler()
+            }
+            else -> {
+                println("NULL")
+                null
+            }
+        }
+    } else {
+        when (newType) {
+            "basic" -> {
+                BasicCardTypeHandler()
+            }
+            "three" -> {
+                ThreeCardTypeHandler()
+            }
+            "hint" -> {
+                HintCardTypeHandler()
+            }
+            "multi" -> {
+                ChoiceCardTypeHandler()
+            }
+            "math" -> {
+                MathCardTypeHandler()
+            }
+            else -> {
+                println("NULL")
+                null
+            }
+        }
+    }
+}
 
 
 

--- a/app/src/main/java/com/example/flashcards/controller/navigation/NavController.kt
+++ b/app/src/main/java/com/example/flashcards/controller/navigation/NavController.kt
@@ -60,14 +60,11 @@ fun AppNavHost(
 ) {
     val cardDeckVM: CardDeckViewModel = viewModel(factory = AppViewModelProvider.Factory)
     val navViewModel: NavViewModel = viewModel(factory = AppViewModelProvider.Factory)
-
-
     val cardsToUpdate by cardDeckVM.cardListToUpdate.collectAsStateWithLifecycle()
     val listState = rememberLazyListState()
     val colorScheme = remember { ColorSchemeClass() }
     var onDeckView by remember { mutableStateOf(false) }
     colorScheme.colorScheme = MaterialTheme.colorScheme
-
     val getModifier = rememberUpdatedState(
         remember {
             GetModifier(
@@ -78,8 +75,6 @@ fun AppNavHost(
     ).value
 
     val selectedCard: MutableState<Card?> = rememberSaveable { mutableStateOf(null) }
-
-
     val cardDeckView = CardDeckView(
         cardDeckVM, getModifier, fields
     )
@@ -100,7 +95,6 @@ fun AppNavHost(
     )
     val addCardView = AddCardView(fields, getModifier)
     val generalSettings = GeneralSettings(getModifier, preferences)
-
     val coroutineScope = rememberCoroutineScope()
     val deck by navViewModel.deck.collectAsStateWithLifecycle()
 
@@ -289,7 +283,6 @@ fun AppNavHost(
                         }
                     }
                 }
-
                 deck?.let {
                     cardDeckView.ViewCard(
                         deck = it,
@@ -309,7 +302,6 @@ fun AppNavHost(
                     )
                 }
             }
-
             composable(EditDeckDestination.route) { backStackEntry ->
                 val deckId = backStackEntry.arguments?.getString("deckId")!!.toIntOrNull()
                 val currentName = backStackEntry.arguments?.getString("currentName")
@@ -336,7 +328,6 @@ fun AppNavHost(
                     )
                 }
             }
-
             composable(ViewAllCardsDestination.route) { backStackEntry ->
                 val deckId = backStackEntry.arguments?.getString("deckId")!!.toIntOrNull()
                 BackHandler {

--- a/app/src/main/java/com/example/flashcards/controller/navigation/NavigationDestination.kt
+++ b/app/src/main/java/com/example/flashcards/controller/navigation/NavigationDestination.kt
@@ -1,57 +1,68 @@
 package com.example.flashcards.controller.navigation
 
+import kotlinx.serialization.Serializable
+
 interface NavigationDestination {
         /**
          * Unique name to define the path for a composable
          */
         val route: String
 }
-
+@Serializable
 object DeckListDestination : NavigationDestination {
         override val route = "DeckList"
 }
+@Serializable
 object SettingsDestination : NavigationDestination {
         override val route = "Settings"
 }
+@Serializable
 object DeckOptionsDestination : NavigationDestination {
         override val route = "DeckOptions/{deckId}"
         fun createRoute(deckId: Int): String {
                 return "DeckOptions/$deckId"
         }
 }
+@Serializable
 object AddDeckDestination : NavigationDestination {
         override val route = "AddDeck"
 }
+@Serializable
 object DeckViewDestination : NavigationDestination {
         override val route = "DeckView/{deckId}"
         fun createRoute(deckId: Int): String {
                 return "DeckView/$deckId"
         }
 }
+@Serializable
 object AddCardDestination : NavigationDestination{
         override val route = "AddCard/{deckId}"
         fun createRoute(deckId: Int): String {
                 return "AddCard/$deckId"
         }
 }
+@Serializable
 object ViewDueCardsDestination : NavigationDestination{
         override val route = "ViewCard/{deckId}"
         fun createRoute(deckId: Int): String {
                 return "ViewCard/$deckId"
         }
 }
+@Serializable
 object EditDeckDestination : NavigationDestination {
         override val route = "EditDeck/{deckId}/{currentName}"
         fun createRoute(deckId: Int, name: String): String{
                 return "EditDeck/${deckId}/${name}"
         }
 }
+@Serializable
 object ViewAllCardsDestination : NavigationDestination{
         override val route = "ViewFlashCards/{deckId}"
         fun createRoute(deckId: Int): String {
                 return "ViewFlashCards/$deckId"
         }
 }
+@Serializable
 object EditingCardDestination : NavigationDestination {
         override val route = "EditingCard/{deckId}/{index}"
         fun createRoute(deckId: Int, index : Int) : String {

--- a/app/src/main/java/com/example/flashcards/controller/onClickActions/CardOnClickActions.kt
+++ b/app/src/main/java/com/example/flashcards/controller/onClickActions/CardOnClickActions.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.ui.res.stringResource
 import com.example.flashcards.R
+import com.example.flashcards.controller.cardHandlers.returnCard
 import com.example.flashcards.controller.viewModels.cardViewsModels.EditCardViewModel
 import com.example.flashcards.model.tablesAndApplication.CT
 import com.example.flashcards.model.tablesAndApplication.Card
@@ -22,7 +23,6 @@ fun saveCard(
     editCardVM: EditCardViewModel,
     ct: CT
 ): Boolean {
-
     when (ct) {
         is CT.Basic -> {
             if (fields.question.value.isNotBlank() && fields.answer.value.isNotBlank()) {
@@ -110,6 +110,80 @@ fun saveCard(
                     },
                     fields.answer.value
                 )
+                return true
+            } else {
+                return false
+            }
+        }
+    }
+    return false
+}
+
+
+suspend fun updateCardType(
+    fields: Fields,
+    editCardVM: EditCardViewModel,
+    ct: CT,
+    newType : String
+): Boolean {
+    val card = returnCard(ct)
+    when (newType) {
+        "basic" -> {
+            if (fields.question.value.isNotBlank() && fields.answer.value.isNotBlank()) {
+                editCardVM.updateCardType(card.id,newType,fields,ct)
+                return true
+            } else {
+                return false
+            }
+        }
+        "three" -> {
+            if (fields.question.value.isNotBlank() && fields.answer.value.isNotBlank()
+                && fields.middleField.value.isNotBlank()
+            ) {
+                editCardVM.updateCardType(card.id,newType,fields,ct)
+                return true
+            } else {
+                return false
+            }
+
+        }
+        "hint" -> {
+            if (fields.question.value.isNotBlank() && fields.answer.value.isNotBlank()
+                && fields.middleField.value.isNotBlank()
+            ) {
+                editCardVM.updateCardType(card.id,newType,fields,ct)
+                return true
+            } else {
+                return false
+            }
+        }
+        "multi" -> {
+            if (
+                fields.question.value.isNotBlank() &&
+                fields.choices[0].value.isNotBlank() &&
+                fields.choices[1].value.isNotBlank() &&
+                !(fields.choices[2].value.isBlank() &&
+                        fields.choices[3].value.isNotBlank()) &&
+                !((fields.choices[2].value.isBlank() &&
+                        fields.correct.value == 'c') ||
+                        (fields.choices[3].value.isBlank() &&
+                                fields.correct.value == 'd')
+                        ) &&
+                fields.correct.value in 'a' .. 'd'
+            ) {
+                editCardVM.updateCardType(card.id,newType,fields,ct)
+                return true
+            } else {
+                return false
+            }
+        }
+        "math" -> {
+            if (fields.question.value.isNotBlank() &&
+                fields.answer.value.isNotBlank() &&
+                ( fields.stringList.isEmpty() ||
+                        fields.stringList.all { it.value.isNotBlank() }
+                        )) {
+                editCardVM.updateCardType(card.id,newType,fields,ct)
                 return true
             } else {
                 return false

--- a/app/src/main/java/com/example/flashcards/controller/viewModels/cardViewsModels/EditCardViewModel.kt
+++ b/app/src/main/java/com/example/flashcards/controller/viewModels/cardViewsModels/EditCardViewModel.kt
@@ -5,8 +5,15 @@ import androidx.lifecycle.viewModelScope
 import com.example.flashcards.model.repositories.CardTypeRepository
 import com.example.flashcards.model.repositories.FlashCardRepository
 import com.example.flashcards.model.repositories.ScienceSpecificRepository
+import com.example.flashcards.model.tablesAndApplication.BasicCard
+import com.example.flashcards.model.tablesAndApplication.CT
 import com.example.flashcards.model.tablesAndApplication.Card
+import com.example.flashcards.model.tablesAndApplication.HintCard
+import com.example.flashcards.model.tablesAndApplication.MathCard
 import com.example.flashcards.model.tablesAndApplication.MathCardConverter
+import com.example.flashcards.model.tablesAndApplication.MultiChoiceCard
+import com.example.flashcards.model.tablesAndApplication.ThreeFieldCard
+import com.example.flashcards.model.uiModels.Fields
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
@@ -67,12 +74,89 @@ class EditCardViewModel(
             )
         }
     }
-    fun updateCardType(
-        cardId: Int, type: String,
+    suspend fun updateCardType(
+        cardId: Int, type: String, fields: Fields,
+        deleteCT : CT
     ) {
         viewModelScope.launch {
-            flashCardRepository.updateCardType(cardId, type)
-        }
+            when (type){
+                "basic" -> {
+                    cardTypeRepository.insertBasicCard(
+                        BasicCard(
+                            cardId =  cardId,
+                            question = fields.question.value,
+                            answer = fields.answer.value
+                        )
+                    )
+                }
+                "three" -> {
+                    cardTypeRepository.insertThreeCard(
+                        ThreeFieldCard(
+                            cardId = cardId,
+                            question = fields.question.value,
+                            middle = fields.middleField.value,
+                            answer = fields.answer.value
+                        )
+                    )
+
+                }
+                "hint" -> {
+                    cardTypeRepository.insertHintCard(
+                        HintCard(
+                            cardId = cardId,
+                            question = fields.question.value,
+                            hint = fields.middleField.value,
+                            answer = fields.answer.value
+                        )
+                    )
+                }
+                "multi" -> {
+                    cardTypeRepository.insertMultiChoiceCard(
+                        MultiChoiceCard(
+                            cardId = cardId,
+                            question = fields.question.value,
+                            choiceA = fields.choices[0].value,
+                            choiceB = fields.choices[1].value,
+                            choiceC = fields.choices[2].value,
+                            choiceD = fields.choices[3].value,
+                            correct = fields.correct.value
+                        )
+                    )
+                }
+                "math" -> {
+                    scienceSpecificRepository.insertMathCard(
+                        MathCard(
+                            cardId = cardId,
+                            question = fields.question.value,
+                            steps = fields.stringList.map { it.value },
+                            answer = fields.answer.value
+                        )
+                    )
+                }
+                else -> {
+                    throw IllegalStateException("Can't update card type")
+                }
+            }.also {
+                flashCardRepository.updateCardType(cardId, type)
+            }
+            when (deleteCT) {
+                is CT.Basic -> {
+                    cardTypeRepository.deleteBasicCard(deleteCT.basicCard)
+                }
+                is CT.ThreeField -> {
+                    cardTypeRepository.deleteThreeCard(deleteCT.threeFieldCard)
+                }
+                is CT.Hint -> {
+                    cardTypeRepository.deleteHintCard(deleteCT.hintCard)
+                }
+                is CT.MultiChoice -> {
+                    cardTypeRepository.deleteMultiChoiceCard(deleteCT.multiChoiceCard)
+                }
+                is CT.Math -> {
+                    scienceSpecificRepository.deleteMathCard(deleteCT.mathCard)
+                }
+            }
+        }.join()
     }
 }
 

--- a/app/src/main/java/com/example/flashcards/model/daoFiles/allCardTypesDao/BasicCardDao.kt
+++ b/app/src/main/java/com/example/flashcards/model/daoFiles/allCardTypesDao/BasicCardDao.kt
@@ -2,6 +2,7 @@ package com.example.flashcards.model.daoFiles.allCardTypesDao
 
 
 import androidx.room.Dao
+import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
@@ -12,8 +13,8 @@ interface BasicCardDao {
     @Insert(onConflict = OnConflictStrategy.ABORT)
     suspend fun insertBasicCard(basicCard: BasicCard) : Long
 
-    @Query("DELETE FROM basicCard WHERE cardId = :cardId")
-    suspend fun deleteBasicCard(cardId : Int)
+    @Delete
+    suspend fun deleteBasicCard(basicCard: BasicCard)
 
     @Query("""
         Update basicCard set question = :newQuestion, 

--- a/app/src/main/java/com/example/flashcards/model/daoFiles/allCardTypesDao/HintCardDao.kt
+++ b/app/src/main/java/com/example/flashcards/model/daoFiles/allCardTypesDao/HintCardDao.kt
@@ -1,6 +1,7 @@
 package com.example.flashcards.model.daoFiles.allCardTypesDao
 
 import androidx.room.Dao
+import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
@@ -12,8 +13,8 @@ interface HintCardDao {
     @Insert(onConflict = OnConflictStrategy.ABORT)
     suspend fun insertHintCard(hintCard: HintCard) : Long
 
-    @Query("DELETE FROM hintCard WHERE cardId = :cardId")
-    suspend fun deleteHintCard(cardId: Int)
+    @Delete
+    suspend fun deleteHintCard(hintCard: HintCard)
 
     @Query("""
         Update hintCard

--- a/app/src/main/java/com/example/flashcards/model/daoFiles/allCardTypesDao/MathCardDao.kt
+++ b/app/src/main/java/com/example/flashcards/model/daoFiles/allCardTypesDao/MathCardDao.kt
@@ -1,6 +1,7 @@
 package com.example.flashcards.model.daoFiles.allCardTypesDao
 
 import androidx.room.Dao
+import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
@@ -9,10 +10,10 @@ import com.example.flashcards.model.tablesAndApplication.MathCard
 @Dao
 interface MathCardDao {
     @Insert(onConflict = OnConflictStrategy.ABORT)
-    fun insertMathCard(mathCard: MathCard): Long
+    suspend fun insertMathCard(mathCard: MathCard): Long
 
-    @Query("DELETE FROM mathCard where cardId = :cardId")
-    fun deleteMathCard(cardId: Int)
+    @Delete
+    suspend fun deleteMathCard(mathCard: MathCard)
 
     @Query("""
         UPDATE mathCard

--- a/app/src/main/java/com/example/flashcards/model/daoFiles/allCardTypesDao/MultiChoiceCardDao.kt
+++ b/app/src/main/java/com/example/flashcards/model/daoFiles/allCardTypesDao/MultiChoiceCardDao.kt
@@ -1,6 +1,7 @@
 package com.example.flashcards.model.daoFiles.allCardTypesDao
 
 import androidx.room.Dao
+import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
@@ -11,8 +12,8 @@ interface MultiChoiceCardDao {
     @Insert(onConflict = OnConflictStrategy.ABORT)
     suspend fun insertMultiChoiceCard(multiChoiceCard: MultiChoiceCard) : Long
 
-    @Query("DELETE FROM multiChoiceCard WHERE cardId = :cardId")
-    suspend fun deleteMultiChoiceCard(cardId : Int)
+    @Delete
+    suspend fun deleteMultiChoiceCard(multiChoiceCard: MultiChoiceCard)
 
     @Query("""
         Update multiChoiceCard set question = :newQuestion, 

--- a/app/src/main/java/com/example/flashcards/model/daoFiles/allCardTypesDao/ThreeCardDao.kt
+++ b/app/src/main/java/com/example/flashcards/model/daoFiles/allCardTypesDao/ThreeCardDao.kt
@@ -1,6 +1,7 @@
 package com.example.flashcards.model.daoFiles.allCardTypesDao
 
 import androidx.room.Dao
+import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
@@ -12,9 +13,8 @@ interface ThreeCardDao {
     @Insert(onConflict = OnConflictStrategy.ABORT)
     suspend fun insertThreeCard(threeFieldCard: ThreeFieldCard) : Long
 
-
-    @Query("DELETE FROM threeFieldCard WHERE cardId = :cardId")
-    suspend fun deleteThreeCard(cardId: Int)
+    @Delete
+    suspend fun deleteThreeCard(threeFieldCard: ThreeFieldCard)
 
     @Query("""
         Update threeFieldCard

--- a/app/src/main/java/com/example/flashcards/model/daoFiles/deckAndCardDao/CardDao.kt
+++ b/app/src/main/java/com/example/flashcards/model/daoFiles/deckAndCardDao/CardDao.kt
@@ -28,6 +28,9 @@ interface CardDao {
     @Query("SELECT * FROM decks WHERE id = :deckId")
     fun getDeckWithCards(deckId: Int): Flow<DeckWithCards>
 
+    @Query("SELECT * FROM cards WHERE id = :cardId")
+    fun getCard(cardId: Int) : Flow<Card>
+
     @Query("SELECT * FROM cards WHERE deckId = :deckId AND nextReview <= :currentTime")
     fun getDueCards(deckId: Int, currentTime: Long = Date().time): Flow<List<Card>>
 
@@ -47,7 +50,7 @@ interface CardDao {
     @Query("DELETE FROM cards WHERE deckId = :deckId")
     suspend fun deleteAllCards(deckId: Int)
 
-    @Query("Update cards set id = :cardId and type = :type")
+    @Query("Update cards set type = :type where id = :cardId")
     suspend fun updateCard(cardId: Int, type: String)
 
     @Query("UPDATE cards SET partOfList = 1 where id = :id")

--- a/app/src/main/java/com/example/flashcards/model/repositories/CardTypeRepository.kt
+++ b/app/src/main/java/com/example/flashcards/model/repositories/CardTypeRepository.kt
@@ -15,10 +15,10 @@ interface CardTypeRepository {
     suspend fun insertHintCard(hintCard: HintCard): Long
     suspend fun insertMultiChoiceCard(multiChoiceCard: MultiChoiceCard): Long
 
-    suspend fun deleteBasicCard(cardId: Int)
-    suspend fun deleteThreeCard(cardId: Int)
-    suspend fun deleteHintCard(cardId: Int)
-    suspend fun deleteMultiChoiceCard(cardId: Int)
+    suspend fun deleteBasicCard(basicCard: BasicCard)
+    suspend fun deleteThreeCard(threeFieldCard: ThreeFieldCard)
+    suspend fun deleteHintCard(hintCard: HintCard)
+    suspend fun deleteMultiChoiceCard(multiChoiceCard: MultiChoiceCard)
 
     suspend fun updateBasicCard(id: Int, question: String, answer: String)
 

--- a/app/src/main/java/com/example/flashcards/model/repositories/FlashCardRepository.kt
+++ b/app/src/main/java/com/example/flashcards/model/repositories/FlashCardRepository.kt
@@ -49,6 +49,7 @@ interface FlashCardRepository {
 
     suspend fun updateCardType(cardId: Int, type: String)
 
+    fun getCardStream(cardId: Int) : Flow<Card>
 
     fun getDeckWithCards(deckId: Int): Flow<DeckWithCards>
 

--- a/app/src/main/java/com/example/flashcards/model/repositories/OfflineCardTypeRepository.kt
+++ b/app/src/main/java/com/example/flashcards/model/repositories/OfflineCardTypeRepository.kt
@@ -30,17 +30,17 @@ class OfflineCardTypeRepository(
     override suspend fun insertMultiChoiceCard(multiChoiceCard: MultiChoiceCard) =
         multiChoiceCardDao.insertMultiChoiceCard(multiChoiceCard)
 
-    override suspend fun deleteBasicCard(cardId: Int) =
-        basicCardDao.deleteBasicCard(cardId)
+    override suspend fun deleteBasicCard(basicCard: BasicCard) =
+        basicCardDao.deleteBasicCard(basicCard)
 
-    override suspend fun deleteHintCard(cardId: Int) =
-        hintCardDao.deleteHintCard(cardId)
+    override suspend fun deleteHintCard(hintCard: HintCard) =
+        hintCardDao.deleteHintCard(hintCard)
 
-    override suspend fun deleteThreeCard(cardId: Int) =
-        threeCardDao.deleteThreeCard(cardId)
+    override suspend fun deleteThreeCard(threeFieldCard: ThreeFieldCard) =
+        threeCardDao.deleteThreeCard(threeFieldCard)
 
-    override suspend fun deleteMultiChoiceCard(cardId: Int) =
-        multiChoiceCardDao.deleteMultiChoiceCard(cardId)
+    override suspend fun deleteMultiChoiceCard(multiChoiceCard: MultiChoiceCard) =
+        multiChoiceCardDao.deleteMultiChoiceCard(multiChoiceCard)
 
     override suspend fun updateBasicCard(id: Int, question: String, answer: String) =
         basicCardDao.updateBasicCard(id, question, answer)

--- a/app/src/main/java/com/example/flashcards/model/repositories/OfflineFlashCardRepository.kt
+++ b/app/src/main/java/com/example/flashcards/model/repositories/OfflineFlashCardRepository.kt
@@ -98,6 +98,8 @@ class OfflineFlashCardRepository(
 
     override suspend fun deleteCard(card: Card) = cardDao.deleteCard(card)
 
+    override fun getCardStream(cardId: Int) = cardDao.getCard(cardId)
+
     @OptIn(FlowPreview::class)
     override fun getDeckWithCards(deckId: Int):
             Flow<DeckWithCards> = cardDao.getDeckWithCards(deckId).debounce(20)

--- a/app/src/main/java/com/example/flashcards/model/repositories/OfflineScienceRepository.kt
+++ b/app/src/main/java/com/example/flashcards/model/repositories/OfflineScienceRepository.kt
@@ -6,12 +6,11 @@ import com.example.flashcards.model.tablesAndApplication.MathCard
 class OfflineScienceRepository(
     private val mathCardDao: MathCardDao
 ) : ScienceSpecificRepository {
-    override fun insertMathCard(mathCard: MathCard) =
+    override suspend fun insertMathCard(mathCard: MathCard) =
         mathCardDao.insertMathCard(mathCard)
 
-    override fun deleteMathCard(cardId: Int) =
-        mathCardDao.deleteMathCard(cardId)
-
+    override suspend fun deleteMathCard(mathCard: MathCard) =
+        mathCardDao.deleteMathCard(mathCard)
     override fun updateMathCard(
         question: String, steps: String,
         answer: String, cardId: Int

--- a/app/src/main/java/com/example/flashcards/model/repositories/ScienceSpecificRepository.kt
+++ b/app/src/main/java/com/example/flashcards/model/repositories/ScienceSpecificRepository.kt
@@ -3,8 +3,8 @@ package com.example.flashcards.model.repositories
 import com.example.flashcards.model.tablesAndApplication.MathCard
 
 interface ScienceSpecificRepository {
-    fun insertMathCard(mathCard: MathCard): Long
-    fun deleteMathCard(cardId: Int)
+    suspend fun insertMathCard(mathCard: MathCard): Long
+    suspend fun deleteMathCard(mathCard: MathCard)
     fun updateMathCard(
         question: String, steps: String,
         answer: String, cardId: Int

--- a/app/src/main/java/com/example/flashcards/views/cardViews/addCardViews/AddMathCard.kt
+++ b/app/src/main/java/com/example/flashcards/views/cardViews/addCardViews/AddMathCard.kt
@@ -158,8 +158,10 @@ fun AddMathCard(
                 }
                 Button(
                     onClick = {
-                        steps -= 1
-                        fields.stringList.removeAt(steps)
+                        if (steps > 0) {
+                            steps -= 1
+                            fields.stringList.removeAt(steps)
+                        }
                     },
                     modifier = Modifier.padding(top = 4.dp),
                     colors = ButtonDefaults.buttonColors(

--- a/app/src/main/java/com/example/flashcards/views/cardViews/editCardViews/EditBasicCard.kt
+++ b/app/src/main/java/com/example/flashcards/views/cardViews/editCardViews/EditBasicCard.kt
@@ -2,31 +2,16 @@ package com.example.flashcards.views.cardViews.editCardViews
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.example.flashcards.R
 import com.example.flashcards.model.uiModels.Fields
-import com.example.flashcards.model.tablesAndApplication.BasicCard
 import com.example.flashcards.views.miscFunctions.EditTextFieldNonDone
-import com.example.flashcards.views.miscFunctions.createBasicCardDetails
 
 @Composable
 fun EditBasicCard(
-    basicCard: BasicCard,
     fields: Fields,
 ) {
-
-    val cardDetails by remember {
-        mutableStateOf(
-            createBasicCardDetails(basicCard)
-        )
-    }
-    fields.question = rememberSaveable { mutableStateOf(cardDetails.question.value) }
-    fields.answer = rememberSaveable { mutableStateOf(cardDetails.answer.value) }
 
     EditTextFieldNonDone(
         value = fields.question.value,

--- a/app/src/main/java/com/example/flashcards/views/cardViews/editCardViews/EditChoiceCard.kt
+++ b/app/src/main/java/com/example/flashcards/views/cardViews/editCardViews/EditChoiceCard.kt
@@ -3,38 +3,20 @@ package com.example.flashcards.views.cardViews.editCardViews
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.example.flashcards.R
-import com.example.flashcards.model.tablesAndApplication.MultiChoiceCard
 import com.example.flashcards.model.uiModels.Fields
 import com.example.flashcards.ui.theme.GetModifier
 import com.example.flashcards.views.miscFunctions.EditTextField
 import com.example.flashcards.views.miscFunctions.EditTextFieldNonDone
 import com.example.flashcards.views.miscFunctions.PickAnswerChar
-import com.example.flashcards.views.miscFunctions.createChoiceCardDetails
 
 @Composable
 fun EditChoiceCard(
-    multiChoiceCard: MultiChoiceCard,
     fields: Fields,
     getModifier: GetModifier
 ) {
-    val cardDetails by remember {
-        mutableStateOf(
-                createChoiceCardDetails(multiChoiceCard)
-        )
-    }
-    fields.question = rememberSaveable { mutableStateOf(cardDetails.question.value) }
-    fields.choices[0] = rememberSaveable { mutableStateOf(cardDetails.choices[0].value) }
-    fields.choices[1] = rememberSaveable { mutableStateOf(cardDetails.choices[1].value) }
-    fields.choices[2] = rememberSaveable { mutableStateOf(cardDetails.choices[2].value) }
-    fields.choices[3] = rememberSaveable { mutableStateOf(cardDetails.choices[3].value) }
-    fields.correct = rememberSaveable { mutableStateOf(cardDetails.correct.value) }
 
 
     EditTextFieldNonDone(

--- a/app/src/main/java/com/example/flashcards/views/cardViews/editCardViews/EditHintCard.kt
+++ b/app/src/main/java/com/example/flashcards/views/cardViews/editCardViews/EditHintCard.kt
@@ -2,36 +2,16 @@ package com.example.flashcards.views.cardViews.editCardViews
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.example.flashcards.R
 import com.example.flashcards.model.uiModels.Fields
-import com.example.flashcards.model.tablesAndApplication.HintCard
 import com.example.flashcards.views.miscFunctions.EditTextFieldNonDone
-import com.example.flashcards.views.miscFunctions.createThreeOrHintCardDetails
 
 @Composable
 fun EditHintCard(
-    hintCard: HintCard,
     fields: Fields
 ) {
-    val cardDetails by remember {
-        mutableStateOf(
-                createThreeOrHintCardDetails(
-                    hintCard.question, hintCard.hint, hintCard.answer
-                )
-        )
-    }
-
-    fields.question = rememberSaveable { mutableStateOf(cardDetails.question.value) }
-    fields.middleField = rememberSaveable { mutableStateOf(cardDetails.middleField.value) }
-    fields.answer = rememberSaveable { mutableStateOf(cardDetails.answer.value) }
-
-
     EditTextFieldNonDone(
         value = fields.question.value,
         onValueChanged = { fields.question.value = it },

--- a/app/src/main/java/com/example/flashcards/views/cardViews/editCardViews/EditMathCard.kt
+++ b/app/src/main/java/com/example/flashcards/views/cardViews/editCardViews/EditMathCard.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -20,33 +19,16 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.flashcards.R
-import com.example.flashcards.model.tablesAndApplication.MathCard
 import com.example.flashcards.model.uiModels.Fields
 import com.example.flashcards.ui.theme.GetModifier
 import com.example.flashcards.views.miscFunctions.EditTextFieldNonDone
-import com.example.flashcards.views.miscFunctions.createMathCardDetails
 
 @Composable
 fun EditMathCard(
-    mathCard: MathCard,
     fields: Fields,
     getModifier : GetModifier
 ) {
-
-    val cardDetails by remember {
-        mutableStateOf(
-            createMathCardDetails(
-                mathCard.question,
-                mathCard.steps,
-                mathCard.answer
-            )
-        )
-    }
-
-    fields.question = rememberSaveable { mutableStateOf(cardDetails.question.value) }
-    fields.stringList = rememberSaveable { cardDetails.stringList }
-    fields.answer = rememberSaveable { mutableStateOf(cardDetails.answer.value) }
-    var steps by rememberSaveable { mutableIntStateOf(cardDetails.stringList.size) }
+    var steps by rememberSaveable { mutableIntStateOf(fields.stringList.size) }
 
     EditTextFieldNonDone(
         value = fields.question.value,
@@ -92,8 +74,10 @@ fun EditMathCard(
         )
         Button(
             onClick = {
-                steps -= 1
-                fields.stringList.removeAt(steps)
+                if (steps > 0) {
+                    steps -= 1
+                    fields.stringList.removeAt(steps)
+                }
             },
             modifier = Modifier.padding(top = 4.dp),
             colors = ButtonDefaults.buttonColors(

--- a/app/src/main/java/com/example/flashcards/views/cardViews/editCardViews/EditThreeCard.kt
+++ b/app/src/main/java/com/example/flashcards/views/cardViews/editCardViews/EditThreeCard.kt
@@ -2,24 +2,17 @@ package com.example.flashcards.views.cardViews.editCardViews
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
+
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.example.flashcards.R
 import com.example.flashcards.model.uiModels.Fields
-import com.example.flashcards.model.tablesAndApplication.ThreeFieldCard
 import com.example.flashcards.views.miscFunctions.EditTextFieldNonDone
 
 @Composable
 fun EditThreeCard(
-    threeCard: ThreeFieldCard,
     fields: Fields
 ) {
-    fields.question = rememberSaveable { mutableStateOf(threeCard.question) }
-    fields.middleField = rememberSaveable { mutableStateOf(threeCard.middle) }
-    fields.answer = rememberSaveable { mutableStateOf(threeCard.answer) }
-
     EditTextFieldNonDone(
         value = fields.question.value,
         onValueChanged = { fields.question.value = it },

--- a/app/src/main/java/com/example/flashcards/views/miscFunctions/Buttons.kt
+++ b/app/src/main/java/com/example/flashcards/views/miscFunctions/Buttons.kt
@@ -1,7 +1,6 @@
 package com.example.flashcards.views.miscFunctions
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -12,6 +11,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material3.Button
@@ -20,10 +20,12 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -32,7 +34,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -276,38 +277,67 @@ fun SystemThemeButton(
 }
 
 @Composable
-fun DeleteCardButton(
+fun CardOptionsButton(
     editCardVM: EditCardViewModel,
     getModifier: GetModifier, card: Card,
     fields: Fields,
+    type: MutableState<String>,
+    expanded: MutableState<Boolean>,
     onDelete: () -> Unit,
-    modifier: Modifier
 ) {
     val coroutineScope = rememberCoroutineScope()
     val showDialog = remember { mutableStateOf(false) }
     Box(
-        modifier = modifier
-            .background(
-                color = getModifier.buttonColor(),
-                shape = RoundedCornerShape(8.dp)
-            )
-            .pointerInput(Unit) {
-                detectTapGestures(
-                    onLongPress = {
-                        showDialog.value = true
-                    }
-                )
-            }
+        Modifier
+            .fillMaxWidth()
+            .wrapContentSize(Alignment.TopEnd)
     ) {
-        Icon(
-            imageVector = Icons.Filled.Delete,
+        IconButton(
+            onClick = { expanded.value = true },
             modifier = Modifier
-                .size(28.dp)
-                .align(Alignment.Center)
-                .padding(2.dp),
-            contentDescription = "Delete Card",
-            tint = getModifier.iconColor()
-        )
+                .padding(4.dp)
+                .size(54.dp)
+        ) {
+            Icon(
+                Icons.Default.MoreVert,
+                contentDescription = "Card Type",
+                tint = getModifier.titleColor()
+            )
+        }
+        DropdownMenu(expanded = expanded.value, onDismissRequest = { expanded.value = false }) {
+            DropdownMenuItem(
+                onClick = { type.value = "basic" },
+                text = { Text(stringResource(R.string.basic_card)) })
+            DropdownMenuItem(
+                onClick = { type.value = "three" },
+                text = { Text(stringResource(R.string.three_field_card)) })
+            DropdownMenuItem(
+                onClick = { type.value = "hint" },
+                text = { Text(stringResource(R.string.hint_card)) })
+            DropdownMenuItem(
+                onClick = { type.value = "multi" },
+                text = { Text(stringResource(R.string.multi_choice_card)) })
+            DropdownMenuItem(
+                onClick = { type.value = "math" },
+                text = { Text("Math") }
+            )
+            HorizontalDivider()
+            DropdownMenuItem(
+                onClick = {
+                    showDialog.value = true
+                },
+                text = {Text("Delete Card")},
+                trailingIcon = {
+                    Icon(
+                        imageVector = Icons.Filled.Delete,
+                        modifier = Modifier
+                            .size(28.dp),
+                        contentDescription = "Delete Card",
+                        tint = getModifier.iconColor()
+                    )
+                }
+            )
+        }
         DeleteCard(
             editCardVM, coroutineScope,
             card, fields, showDialog,

--- a/app/src/main/java/com/example/flashcards/views/miscFunctions/CardDetails.kt
+++ b/app/src/main/java/com/example/flashcards/views/miscFunctions/CardDetails.kt
@@ -17,12 +17,12 @@ data class CardDetails(
 fun createChoiceCardDetails(multiChoiceCard: MultiChoiceCard): CardDetails {
     return CardDetails(
         question = mutableStateOf(multiChoiceCard.question),
-        choices = MutableList(4) {
-                mutableStateOf(multiChoiceCard.choiceA)
-                mutableStateOf(multiChoiceCard.choiceB)
-                mutableStateOf(multiChoiceCard.choiceC)
-                mutableStateOf(multiChoiceCard.choiceD)
-        },
+        choices = mutableListOf(
+                mutableStateOf(multiChoiceCard.choiceA),
+                mutableStateOf(multiChoiceCard.choiceB),
+                mutableStateOf(multiChoiceCard.choiceC),
+                mutableStateOf(multiChoiceCard.choiceD),
+        ),
         correct = mutableStateOf(multiChoiceCard.correct)
     )
 }

--- a/app/src/main/java/com/example/flashcards/views/miscFunctions/KeyboardInputs.kt
+++ b/app/src/main/java/com/example/flashcards/views/miscFunctions/KeyboardInputs.kt
@@ -32,16 +32,12 @@ fun EditTextField(
         TextFieldDefaults.colors(
             focusedTextColor = MaterialTheme.colorScheme.onBackground,
             unfocusedTextColor = MaterialTheme.colorScheme.onBackground,
-            focusedContainerColor = MaterialTheme.colorScheme.surfaceContainer,
-            unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainer
 
         )
     } else {
         TextFieldDefaults.colors(
             unfocusedTextColor = inputColor,
             focusedTextColor = inputColor,
-            focusedContainerColor = MaterialTheme.colorScheme.surfaceContainer,
-            unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainer
         )
     }
     TextField(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.8.0" # to run on koala -> 8.6.1
+agp = "8.8.1" # to run on koala -> 8.6.1
 kotlin = "2.0.0"
 coreKtx = "1.13.1"
 junit = "4.13.2"


### PR DESCRIPTION
## Summary by Sourcery

Allow users to change the card type of existing flashcards. Update the UI to dynamically display the appropriate editing fields based on the selected card type.  Implement the logic to save the updated card details to the database.

Enhancements:
- Allow users to change the card type of a flashcard.
- Refactor card editing views to support changing card types.
- Add a dropdown menu to the card editing view to allow users to select a new card type.
- Update the card type repository to delete the old card type when a new type is selected.
- Update the card view model to handle updating the card type in the database.
- Add functions to create card details based on the selected card type.
- Add a function to return the correct card type handler based on the selected card type.
- Update the navigation destination objects to be serializable.
- Update the Gradle version to 8.8.1 and add a comment to indicate the version to use for Koala.