### PR TITLE
katex-menu

### DIFF
--- a/app/src/main/java/com/belmontCrest/cardCrafter/controller/cardHandlers/CardTypeHandler.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/controller/cardHandlers/CardTypeHandler.kt
@@ -5,6 +5,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Modifier
+import com.belmontCrest.cardCrafter.controller.viewModels.cardViewsModels.EditCardViewModel
 import com.belmontCrest.cardCrafter.localDatabase.tables.CT
 import com.belmontCrest.cardCrafter.model.uiModels.Fields
 import com.belmontCrest.cardCrafter.views.cardViews.editCardViews.EditBasicCard
@@ -21,20 +23,16 @@ import com.belmontCrest.cardCrafter.views.miscFunctions.details.createThreeOrHin
 interface CardTypeHandler {
     @Composable
     fun HandleCardEdit(
-        fields: Fields,
-        ct : CT,
-        changed : Boolean,
-        getUIStyle: GetUIStyle
+        fields: Fields, ct: CT, vm: EditCardViewModel,
+        changed: Boolean, getUIStyle: GetUIStyle, modifier: Modifier
     )
 }
 
 class BasicCardTypeHandler : CardTypeHandler {
     @Composable
     override fun HandleCardEdit(
-        fields: Fields,
-        ct : CT,
-        changed : Boolean,
-        getUIStyle: GetUIStyle
+        fields: Fields, ct: CT, vm: EditCardViewModel,
+        changed: Boolean, getUIStyle: GetUIStyle, modifier: Modifier
     ) {
 
         if (ct is CT.Basic) {
@@ -65,12 +63,10 @@ class BasicCardTypeHandler : CardTypeHandler {
 class ThreeCardTypeHandler : CardTypeHandler {
     @Composable
     override fun HandleCardEdit(
-        fields: Fields,
-        ct : CT,
-        changed : Boolean,
-        getUIStyle: GetUIStyle
+        fields: Fields, ct: CT, vm: EditCardViewModel,
+        changed: Boolean, getUIStyle: GetUIStyle, modifier: Modifier
     ) {
-        if (ct is CT.ThreeField){
+        if (ct is CT.ThreeField) {
             if (!changed) {
                 val cardDetails by remember {
                     mutableStateOf(
@@ -82,11 +78,14 @@ class ThreeCardTypeHandler : CardTypeHandler {
                     )
                 }
                 fields.question = rememberSaveable {
-                    mutableStateOf(cardDetails.question.value) }
+                    mutableStateOf(cardDetails.question.value)
+                }
                 fields.middleField = rememberSaveable {
-                    mutableStateOf(cardDetails.middleField.value) }
+                    mutableStateOf(cardDetails.middleField.value)
+                }
                 fields.answer = rememberSaveable {
-                    mutableStateOf(cardDetails.answer.value) }
+                    mutableStateOf(cardDetails.answer.value)
+                }
             }
             EditThreeCard(fields)
         } else {
@@ -106,13 +105,11 @@ class ThreeCardTypeHandler : CardTypeHandler {
 class HintCardTypeHandler : CardTypeHandler {
     @Composable
     override fun HandleCardEdit(
-        fields: Fields,
-        ct : CT,
-        changed : Boolean,
-        getUIStyle: GetUIStyle
+        fields: Fields, ct: CT, vm: EditCardViewModel,
+        changed: Boolean, getUIStyle: GetUIStyle, modifier: Modifier
     ) {
         if (ct is CT.Hint) {
-            if (!changed){
+            if (!changed) {
                 val cardDetails by remember {
                     mutableStateOf(
                         createThreeOrHintCardDetails(
@@ -121,11 +118,14 @@ class HintCardTypeHandler : CardTypeHandler {
                     )
                 }
                 fields.question = rememberSaveable {
-                    mutableStateOf(cardDetails.question.value) }
+                    mutableStateOf(cardDetails.question.value)
+                }
                 fields.middleField = rememberSaveable {
-                    mutableStateOf(cardDetails.middleField.value) }
+                    mutableStateOf(cardDetails.middleField.value)
+                }
                 fields.answer = rememberSaveable {
-                    mutableStateOf(cardDetails.answer.value) }
+                    mutableStateOf(cardDetails.answer.value)
+                }
             }
             EditHintCard(fields)
         } else {
@@ -145,13 +145,11 @@ class HintCardTypeHandler : CardTypeHandler {
 class ChoiceCardTypeHandler : CardTypeHandler {
     @Composable
     override fun HandleCardEdit(
-        fields: Fields,
-        ct : CT,
-        changed : Boolean,
-        getUIStyle: GetUIStyle
+        fields: Fields, ct: CT, vm: EditCardViewModel,
+        changed: Boolean, getUIStyle: GetUIStyle, modifier: Modifier
     ) {
         if (ct is CT.MultiChoice) {
-            if (!changed){
+            if (!changed) {
                 val cardDetails by remember {
                     mutableStateOf(
                         createChoiceCardDetails(ct.multiChoiceCard)
@@ -159,13 +157,17 @@ class ChoiceCardTypeHandler : CardTypeHandler {
                 }
                 fields.question = rememberSaveable { mutableStateOf(cardDetails.question.value) }
                 fields.choices[0].value = rememberSaveable {
-                    cardDetails.choices[0].value }
+                    cardDetails.choices[0].value
+                }
                 fields.choices[1].value = rememberSaveable {
-                   cardDetails.choices[1].value }
+                    cardDetails.choices[1].value
+                }
                 fields.choices[2].value = rememberSaveable {
-                    cardDetails.choices[2].value }
+                    cardDetails.choices[2].value
+                }
                 fields.choices[3].value = rememberSaveable {
-                    cardDetails.choices[3].value }
+                    cardDetails.choices[3].value
+                }
                 fields.correct = rememberSaveable { mutableStateOf(cardDetails.correct.value) }
             }
             EditChoiceCard(fields, getUIStyle)
@@ -186,13 +188,11 @@ class ChoiceCardTypeHandler : CardTypeHandler {
 class NotationCardTypeHandler : CardTypeHandler {
     @Composable
     override fun HandleCardEdit(
-        fields: Fields,
-        ct: CT,
-        changed : Boolean,
-        getUIStyle: GetUIStyle
+        fields: Fields, ct: CT, vm: EditCardViewModel,
+        changed: Boolean, getUIStyle: GetUIStyle, modifier : Modifier
     ) {
-        if (ct is CT.Notation){
-            if (!changed){
+        if (ct is CT.Notation) {
+            if (!changed) {
                 val cardDetails by remember {
                     mutableStateOf(
                         createNotationCardDetails(
@@ -206,39 +206,44 @@ class NotationCardTypeHandler : CardTypeHandler {
                 fields.stringList = rememberSaveable { cardDetails.stringList }
                 fields.answer = rememberSaveable { mutableStateOf(cardDetails.answer.value) }
             }
-            EditNotationCard(fields, getUIStyle)
+            EditNotationCard(fields, vm, getUIStyle, modifier)
         } else {
             if (ct is CT.Basic) {
-                EditNotationCard(fields, getUIStyle)
+                EditNotationCard(fields, vm, getUIStyle, modifier)
             } else if (ct is CT.ThreeField) {
-                EditNotationCard(fields, getUIStyle)
+                EditNotationCard(fields, vm, getUIStyle, modifier)
             } else if (ct is CT.Hint) {
-                EditNotationCard(fields, getUIStyle)
+                EditNotationCard(fields, vm, getUIStyle, modifier)
             } else if (ct is CT.MultiChoice) {
-                EditNotationCard(fields, getUIStyle)
+                EditNotationCard(fields, vm, getUIStyle, modifier)
             }
         }
     }
 }
 
-fun returnCardTypeHandler(newType : String, currentType : String) : CardTypeHandler? {
+fun returnCardTypeHandler(newType: String, currentType: String): CardTypeHandler? {
     return if (newType == currentType) {
         when (currentType) {
             "basic" -> {
                 BasicCardTypeHandler()
             }
+
             "three" -> {
                 ThreeCardTypeHandler()
             }
+
             "hint" -> {
                 HintCardTypeHandler()
             }
+
             "multi" -> {
                 ChoiceCardTypeHandler()
             }
+
             "notation" -> {
                 NotationCardTypeHandler()
             }
+
             else -> {
                 null
             }
@@ -248,18 +253,23 @@ fun returnCardTypeHandler(newType : String, currentType : String) : CardTypeHand
             "basic" -> {
                 BasicCardTypeHandler()
             }
+
             "three" -> {
                 ThreeCardTypeHandler()
             }
+
             "hint" -> {
                 HintCardTypeHandler()
             }
+
             "multi" -> {
                 ChoiceCardTypeHandler()
             }
+
             "notation" -> {
                 NotationCardTypeHandler()
             }
+
             else -> {
                 null
             }

--- a/app/src/main/java/com/belmontCrest/cardCrafter/controller/viewModels/cardViewsModels/AddCardViewModel.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/controller/viewModels/cardViewsModels/AddCardViewModel.kt
@@ -29,6 +29,8 @@ class AddCardViewModel(
     val showKatexKeyboard = _showKatexKeyboard.asStateFlow()
     private val _selectedKB : MutableStateFlow<SelectedKeyboard?> = MutableStateFlow(null)
     val selectedKB = _selectedKB.asStateFlow()
+    private val _resetOffset = MutableStateFlow(false)
+    val resetOffset = _resetOffset.asStateFlow()
 
     companion object {
         private const val TIMEOUT_MILLIS = 4_000L
@@ -173,6 +175,14 @@ class AddCardViewModel(
 
     fun toggleKeyboard() {
         _showKatexKeyboard.update { !it }
+    }
+
+    fun resetOffset() {
+        _resetOffset.update { true }
+    }
+
+    fun resetDone() {
+        _resetOffset.update { false }
     }
 
     fun setErrorMessage(message: String) {

--- a/app/src/main/java/com/belmontCrest/cardCrafter/controller/viewModels/cardViewsModels/EditCardViewModel.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/controller/viewModels/cardViewsModels/EditCardViewModel.kt
@@ -7,6 +7,7 @@ import com.belmontCrest.cardCrafter.localDatabase.dbInterface.repositories.Scien
 import com.belmontCrest.cardCrafter.localDatabase.tables.CT
 import com.belmontCrest.cardCrafter.localDatabase.tables.ListStringConverter
 import com.belmontCrest.cardCrafter.model.uiModels.Fields
+import com.belmontCrest.cardCrafter.model.uiModels.SelectedKeyboard
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -21,6 +22,13 @@ class EditCardViewModel(
     private val listStringConverter = ListStringConverter()
     private val privateErrMessage = MutableStateFlow("")
     val errorMessage = privateErrMessage.asStateFlow()
+    private val _showKatexKeyboard = MutableStateFlow(false)
+    val showKatexKeyboard = _showKatexKeyboard.asStateFlow()
+    private val _selectedKB : MutableStateFlow<SelectedKeyboard?> = MutableStateFlow(null)
+    val selectedKB = _selectedKB.asStateFlow()
+    private val _resetOffset = MutableStateFlow(false)
+    val resetOffset = _resetOffset.asStateFlow()
+
     fun updateBasicCard(cardId: Int, question: String, answer: String) {
         viewModelScope.launch {
             cardTypeRepository.updateBasicCard(cardId, question, answer)
@@ -77,6 +85,26 @@ class EditCardViewModel(
         viewModelScope.launch {
             cardTypeRepository.updateCT(cardId, type, fields, deleteCT)
         }.join()
+    }
+
+    fun updateSelectedKB(selectedKeyboard: SelectedKeyboard) {
+        _selectedKB.update { selectedKeyboard }
+    }
+
+    fun resetSelectedKB() {
+        _selectedKB.update { null }
+    }
+
+    fun toggleKeyboard() {
+        _showKatexKeyboard.update { !it }
+    }
+
+    fun resetOffset() {
+        _resetOffset.update { true }
+    }
+
+    fun resetDone() {
+        _resetOffset.update { false }
     }
 
     fun setErrorMessage(message: String) {

--- a/app/src/main/java/com/belmontCrest/cardCrafter/navigation/drawer/ActionsIconButton.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/navigation/drawer/ActionsIconButton.kt
@@ -38,7 +38,7 @@ import com.belmontCrest.cardCrafter.navigation.destinations.ExportSBDestination
 import com.belmontCrest.cardCrafter.navigation.destinations.MainNavDestination
 import com.belmontCrest.cardCrafter.navigation.destinations.UserProfileDestination
 import com.belmontCrest.cardCrafter.supabase.controller.viewModels.SupabaseViewModel
-import com.belmontCrest.cardCrafter.supabase.view.uploadDeck.CardPickerDropdown
+import com.belmontCrest.cardCrafter.supabase.view.exportDeck.CardPickerDropdown
 import com.belmontCrest.cardCrafter.ui.theme.GetUIStyle
 import com.belmontCrest.cardCrafter.ui.theme.backButtonModifier
 import com.belmontCrest.cardCrafter.ui.theme.redoButtonModifier

--- a/app/src/main/java/com/belmontCrest/cardCrafter/navigation/navHosts/SBNavHost.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/navigation/navHosts/SBNavHost.kt
@@ -42,7 +42,7 @@ import com.belmontCrest.cardCrafter.supabase.view.profile.UserExportedDecks
 import com.belmontCrest.cardCrafter.supabase.view.profile.MyProfile
 import com.belmontCrest.cardCrafter.supabase.view.importDeck.ImportDeck
 import com.belmontCrest.cardCrafter.supabase.view.OnlineDatabase
-import com.belmontCrest.cardCrafter.supabase.view.uploadDeck.UploadThisDeck
+import com.belmontCrest.cardCrafter.supabase.view.exportDeck.UploadThisDeck
 import com.belmontCrest.cardCrafter.supabase.view.authViews.email.EmailView
 import com.belmontCrest.cardCrafter.supabase.view.authViews.email.ForgotPassword
 import com.belmontCrest.cardCrafter.supabase.view.profile.CardListView

--- a/app/src/main/java/com/belmontCrest/cardCrafter/supabase/view/exportDeck/CardPickerDropdown.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/supabase/view/exportDeck/CardPickerDropdown.kt
@@ -1,4 +1,4 @@
-package com.belmontCrest.cardCrafter.supabase.view.uploadDeck
+package com.belmontCrest.cardCrafter.supabase.view.exportDeck
 
 import android.os.Build
 import androidx.annotation.RequiresApi

--- a/app/src/main/java/com/belmontCrest/cardCrafter/supabase/view/exportDeck/FailedUpload.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/supabase/view/exportDeck/FailedUpload.kt
@@ -1,4 +1,4 @@
-package com.belmontCrest.cardCrafter.supabase.view.uploadDeck
+package com.belmontCrest.cardCrafter.supabase.view.exportDeck
 
 import android.os.Build
 import androidx.annotation.RequiresApi

--- a/app/src/main/java/com/belmontCrest/cardCrafter/supabase/view/exportDeck/SelectDeckToExport.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/supabase/view/exportDeck/SelectDeckToExport.kt
@@ -1,4 +1,4 @@
-package com.belmontCrest.cardCrafter.supabase.view.uploadDeck
+package com.belmontCrest.cardCrafter.supabase.view.exportDeck
 
 import android.os.Build
 import androidx.annotation.RequiresApi

--- a/app/src/main/java/com/belmontCrest/cardCrafter/supabase/view/exportDeck/UploadThisDeck.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/supabase/view/exportDeck/UploadThisDeck.kt
@@ -1,4 +1,4 @@
-package com.belmontCrest.cardCrafter.supabase.view.uploadDeck
+package com.belmontCrest.cardCrafter.supabase.view.exportDeck
 
 import android.os.Build
 import androidx.annotation.RequiresApi

--- a/app/src/main/java/com/belmontCrest/cardCrafter/supabase/view/importDeck/DisplayCardDetails.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/supabase/view/importDeck/DisplayCardDetails.kt
@@ -1,10 +1,12 @@
 package com.belmontCrest.cardCrafter.supabase.view.importDeck
 
 import android.annotation.SuppressLint
+import android.util.Log
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
@@ -15,7 +17,7 @@ import com.belmontCrest.cardCrafter.model.Type
 import com.belmontCrest.cardCrafter.supabase.model.tables.SBDeckDto
 import com.belmontCrest.cardCrafter.ui.theme.GetUIStyle
 import com.belmontCrest.cardCrafter.views.miscFunctions.details.CardDetails
-import com.belmontCrest.cardCrafter.uiFunctions.symbols.toShortHex
+import com.belmontCrest.cardCrafter.uiFunctions.katex.toShortHex
 
 
 @SuppressLint("SetJavaScriptEnabled")
@@ -29,6 +31,15 @@ fun DisplayCardDetails(
     val backgroundToHex = getUIStyle.background().toShortHex()
     val textToHex = getUIStyle.titleColor().toShortHex()
     val borderColor = getUIStyle.defaultIconColor().toShortHex()
+    DisposableEffect(webView) {
+        onDispose {
+            try {
+                webView.destroy()
+            } catch (e: Exception) {
+                Log.w("KatexMenu", "Failed to destroy WebView: $e")
+            }
+        }
+    }
     AndroidView(
         factory = {
             webView.apply {
@@ -42,23 +53,29 @@ fun DisplayCardDetails(
                         view.evaluateJavascript("setTheme('$backgroundToHex','$textToHex');", null)
 
                         // deck title
-                        view.evaluateJavascript("""
+                        view.evaluateJavascript(
+                            """
                         |document.getElementById('deckTitle').innerText = `${deck.name}`;
-                        """.trimMargin(), null)
+                        """.trimMargin(), null
+                        )
 
                         // description
-                        view.evaluateJavascript("""
+                        view.evaluateJavascript(
+                            """
                         |document.getElementById('description').innerHTML = `${deck.description}`;
                         |renderNotation(document.getElementById('description'));
-                        """.trimMargin(), null)
+                        """.trimMargin(), null
+                        )
 
                         // up to four cards
                         allCardDetails.forEachIndexed { i, (cd, type) ->
                             val html = cd.toHTML(type)
-                            view.evaluateJavascript("""
+                            view.evaluateJavascript(
+                                """
                             |document.getElementById('card$i').innerHTML = `$html`;
                             |renderNotation(document.getElementById('card$i'));
-                            """.trimMargin(), null)
+                            """.trimMargin(), null
+                            )
                         }
                         view.evaluateJavascript("setBorderColor('$borderColor');", null)
                         onLoading(false)

--- a/app/src/main/java/com/belmontCrest/cardCrafter/supabase/view/profile/UserExportedDecks.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/supabase/view/profile/UserExportedDecks.kt
@@ -30,7 +30,7 @@ import com.belmontCrest.cardCrafter.supabase.controller.viewModels.SupabaseViewM
 import com.belmontCrest.cardCrafter.supabase.controller.viewModels.UserExportedDecksViewModel
 import com.belmontCrest.cardCrafter.supabase.model.tables.SBDeckDto
 import com.belmontCrest.cardCrafter.supabase.view.authViews.CreateAccount
-import com.belmontCrest.cardCrafter.supabase.view.uploadDeck.LocalDecks
+import com.belmontCrest.cardCrafter.supabase.view.exportDeck.LocalDecks
 import com.belmontCrest.cardCrafter.ui.theme.GetUIStyle
 import com.belmontCrest.cardCrafter.ui.theme.boxViewsModifier
 import com.belmontCrest.cardCrafter.uiFunctions.ExportDeckButton

--- a/app/src/main/java/com/belmontCrest/cardCrafter/uiFunctions/KeyboardInputs.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/uiFunctions/KeyboardInputs.kt
@@ -35,8 +35,8 @@ import androidx.compose.ui.unit.sp
 import com.belmontCrest.cardCrafter.R
 import com.belmontCrest.cardCrafter.ui.theme.GetUIStyle
 import com.belmontCrest.cardCrafter.ui.theme.textColor
-import com.belmontCrest.cardCrafter.uiFunctions.symbols.isInside
-import com.belmontCrest.cardCrafter.uiFunctions.symbols.katexMapper
+import com.belmontCrest.cardCrafter.uiFunctions.katex.isInside
+import com.belmontCrest.cardCrafter.uiFunctions.katex.katexMapper
 
 private object KeyboardInputs {
     const val KK = "KatexKeyBoard"

--- a/app/src/main/java/com/belmontCrest/cardCrafter/uiFunctions/katex/KaTeXMenu.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/uiFunctions/katex/KaTeXMenu.kt
@@ -1,8 +1,9 @@
-package com.belmontCrest.cardCrafter.uiFunctions
+package com.belmontCrest.cardCrafter.uiFunctions.katex
 
 import android.annotation.SuppressLint
 import android.os.Handler
 import android.os.Looper
+import android.util.Log
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -17,7 +18,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -25,12 +31,12 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import com.belmontCrest.cardCrafter.ui.theme.GetUIStyle
-import com.belmontCrest.cardCrafter.uiFunctions.symbols.toShortHex
 import kotlin.math.roundToInt
 
 
@@ -63,7 +69,7 @@ private val OTHER_LETTERS = listOf(
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
 fun KaTeXMenu(
-    modifier: Modifier, offset: Offset,
+    modifier: Modifier, offset: Offset, onDismiss: () -> Unit,
     onOffset: (Offset) -> Unit, getUIStyle: GetUIStyle,
     onSelectNotation: (String) -> Unit
 ) {
@@ -71,6 +77,8 @@ fun KaTeXMenu(
     val textToHex = getUIStyle.titleColor().toShortHex()
     val webView = remember {
         WebView(context).apply {
+            isFocusable = false
+            isFocusableInTouchMode = false
             setBackgroundColor(getUIStyle.katexMenuBGColor().toArgb())
             settings.javaScriptEnabled = true
             // expose a Kotlin callback under “Android” in JS
@@ -149,6 +157,15 @@ fun KaTeXMenu(
         }
     }
 
+    DisposableEffect(webView) {
+        onDispose {
+            try {
+                webView.destroy()
+            } catch (e: Exception) {
+                Log.w("KatexMenu", "Failed to destroy WebView: $e")
+            }
+        }
+    }
 
     Box(
         modifier = modifier
@@ -171,9 +188,20 @@ fun KaTeXMenu(
             Text(
                 text = "Drag here",
                 modifier = Modifier.align(Alignment.Center),
+                textAlign = TextAlign.Center,
                 fontSize = 16.sp,
                 color = getUIStyle.titleColor()
             )
+            IconButton(
+                onClick = { onDismiss() },
+                modifier = Modifier.align(Alignment.TopEnd)
+            ) {
+                Icon(
+                    Icons.Filled.Close,
+                    contentDescription = null
+                )
+            }
+
         }
         AndroidView(
             factory = { webView },

--- a/app/src/main/java/com/belmontCrest/cardCrafter/uiFunctions/katex/KatexMapping.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/uiFunctions/katex/KatexMapping.kt
@@ -1,4 +1,4 @@
-package com.belmontCrest.cardCrafter.uiFunctions.symbols
+package com.belmontCrest.cardCrafter.uiFunctions.katex
 
 import android.util.Log
 import androidx.compose.ui.text.TextRange

--- a/app/src/main/java/com/belmontCrest/cardCrafter/uiFunctions/katex/KatexView.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/uiFunctions/katex/KatexView.kt
@@ -1,10 +1,12 @@
-package com.belmontCrest.cardCrafter.uiFunctions.symbols
+package com.belmontCrest.cardCrafter.uiFunctions.katex
 
 import android.annotation.SuppressLint
+import android.util.Log
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -23,6 +25,17 @@ fun KaTeXWebView(latexExpression: String, getUIStyle: GetUIStyle) {
 
     val backgroundToHex = getUIStyle.background().toShortHex()
     val textToHex = getUIStyle.titleColor().toShortHex()
+
+    DisposableEffect(webView) {
+        onDispose {
+            try {
+                webView.destroy()
+            } catch (e: Exception) {
+                Log.w("KatexMenu", "Failed to destroy WebView: $e")
+            }
+        }
+    }
+
     AndroidView(
         factory = {
             webView.apply {
@@ -30,7 +43,8 @@ fun KaTeXWebView(latexExpression: String, getUIStyle: GetUIStyle) {
                 setBackgroundColor(getUIStyle.background().toArgb())
 
             }
-        }, modifier = Modifier
+        },
+        modifier = Modifier
             .fillMaxWidth()
             .zIndex(-1f),
     ) { view ->

--- a/app/src/main/java/com/belmontCrest/cardCrafter/uiFunctions/katex/SymbolDocumentation.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/uiFunctions/katex/SymbolDocumentation.kt
@@ -1,4 +1,4 @@
-package com.belmontCrest.cardCrafter.uiFunctions.symbols
+package com.belmontCrest.cardCrafter.uiFunctions.katex
 
 
 import androidx.compose.foundation.clickable

--- a/app/src/main/java/com/belmontCrest/cardCrafter/views/cardViews/addCardViews/AddCardView.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/views/cardViews/addCardViews/AddCardView.kt
@@ -3,6 +3,7 @@ package com.belmontCrest.cardCrafter.views.cardViews.addCardViews
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -11,15 +12,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.ui.AbsoluteAlignment
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -39,7 +39,7 @@ import com.belmontCrest.cardCrafter.model.uiModels.Fields
 import com.belmontCrest.cardCrafter.ui.theme.GetUIStyle
 import com.belmontCrest.cardCrafter.ui.theme.boxViewsModifier
 import com.belmontCrest.cardCrafter.views.miscFunctions.getSavableFields
-import com.belmontCrest.cardCrafter.uiFunctions.symbols.SymbolDocumentation
+import com.belmontCrest.cardCrafter.uiFunctions.katex.SymbolDocumentation
 
 
 class AddCardView(
@@ -63,11 +63,16 @@ class AddCardView(
         ) {
             SymbolDocumentation(helpForNotation, getUIStyle)
             if (type == Type.NOTATION && selectedKB != null) {
-                IconButton(
-                    onClick = { addCardVM.toggleKeyboard() },
+                Box(
                     modifier = Modifier
                         .align(Alignment.TopStart)
                         .size(30.dp)
+                        .pointerInput(Unit) {
+                            detectTapGestures(
+                                onTap = { addCardVM.toggleKeyboard() },
+                                onLongPress = { addCardVM.resetOffset() }
+                            )
+                        }
                 ) {
                     if (!showKB) {
                         Icon(
@@ -169,7 +174,7 @@ class AddCardView(
                         addCardVM, deck,
                         fields, getUIStyle, Modifier
                             .zIndex(2f)
-                            .align(AbsoluteAlignment.Left)
+                            .align(Alignment.Start)
                             .padding(6.dp)
                     )
 

--- a/app/src/main/java/com/belmontCrest/cardCrafter/views/cardViews/cardDeckViews/BackCards.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/views/cardViews/cardDeckViews/BackCards.kt
@@ -25,7 +25,7 @@ import com.belmontCrest.cardCrafter.localDatabase.tables.NotationCard
 import com.belmontCrest.cardCrafter.localDatabase.tables.MultiChoiceCard
 import com.belmontCrest.cardCrafter.localDatabase.tables.ThreeFieldCard
 import com.belmontCrest.cardCrafter.ui.theme.GetUIStyle
-import com.belmontCrest.cardCrafter.uiFunctions.symbols.KaTeXWebView
+import com.belmontCrest.cardCrafter.uiFunctions.katex.KaTeXWebView
 
 private const val line = "$$\\\\text{---}\\\\text{---}\\\\text{---}\\\\text{---}\\\\text{---}" +
         "\\\\text{---}\\\\text{---}\\\\text{---}$$"

--- a/app/src/main/java/com/belmontCrest/cardCrafter/views/cardViews/cardDeckViews/FrontCards.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/views/cardViews/cardDeckViews/FrontCards.kt
@@ -32,7 +32,7 @@ import com.belmontCrest.cardCrafter.ui.theme.GetUIStyle
 import com.belmontCrest.cardCrafter.R
 import com.belmontCrest.cardCrafter.localDatabase.tables.CT
 import com.belmontCrest.cardCrafter.localDatabase.tables.NotationCard
-import com.belmontCrest.cardCrafter.uiFunctions.symbols.KaTeXWebView
+import com.belmontCrest.cardCrafter.uiFunctions.katex.KaTeXWebView
 
 @Composable
 fun FrontCard(

--- a/app/src/main/java/com/belmontCrest/cardCrafter/views/cardViews/editCardViews/EditNotationCard.kt
+++ b/app/src/main/java/com/belmontCrest/cardCrafter/views/cardViews/editCardViews/EditNotationCard.kt
@@ -1,6 +1,9 @@
 package com.belmontCrest.cardCrafter.views.cardViews.editCardViews
 
-import androidx.compose.foundation.clickable
+import android.util.Log
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -8,107 +11,202 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.belmontCrest.cardCrafter.R
+import com.belmontCrest.cardCrafter.controller.viewModels.cardViewsModels.EditCardViewModel
 import com.belmontCrest.cardCrafter.model.uiModels.Fields
+import com.belmontCrest.cardCrafter.model.uiModels.SelectedKeyboard
 import com.belmontCrest.cardCrafter.ui.theme.GetUIStyle
 import com.belmontCrest.cardCrafter.uiFunctions.LatexKeyboard
+import com.belmontCrest.cardCrafter.uiFunctions.katex.KaTeXMenu
+import com.belmontCrest.cardCrafter.uiFunctions.showToastMessage
 
 @Composable
 fun EditNotationCard(
-    fields: Fields,
-    getUIStyle: GetUIStyle
+    fields: Fields, vm: EditCardViewModel,
+    getUIStyle: GetUIStyle, modifier: Modifier
 ) {
     var steps by rememberSaveable { mutableIntStateOf(fields.stringList.size) }
     val focusRequester = remember { FocusRequester() }
     var selectedQSymbol by rememberSaveable { mutableStateOf<String?>(null) }
     var selectedASymbol by rememberSaveable { mutableStateOf<String?>(null) }
     var selectedSLSymbols = rememberSaveable { mutableListOf<String?>() }
-
-    LatexKeyboard(
-        value = fields.question.value,
-        onValueChanged = { fields.question.value = it },
-        labelStr = stringResource(R.string.question),
-        modifier = Modifier.fillMaxWidth(),
-        focusRequester = focusRequester,
-        symbol = selectedQSymbol,
-        onSymbol = { selectedQSymbol = null }
-    )
-    if (steps == 0) {
-        Text(
-            text = "Add a step",
-            modifier = Modifier
-                .fillMaxSize()
-                .clickable {
-                    steps = 1
-                    fields.stringList.add(mutableStateOf(""))
-                    selectedSLSymbols.add(null)
-                }
-                .padding(8.dp),
-            textAlign = TextAlign.Center,
-            fontSize = 18.sp
-        )
-    } else {
-        fields.stringList.forEachIndexed { index, string ->
-            LatexKeyboard(
-                value = string.value,
-                onValueChanged = { string.value = it },
-                labelStr = "Step: ${index + 1}",
-                modifier = Modifier.fillMaxWidth(),
-                focusRequester = focusRequester,
-                symbol = selectedSLSymbols[index],
-                onSymbol = { selectedSLSymbols[index] = null }
-            )
-        }
-        Text(
-            text = "Add a step",
-            modifier = Modifier
-                .fillMaxSize()
-                .clickable {
-                    steps += 1
-                    fields.stringList.add(mutableStateOf(""))
-                    selectedSLSymbols.add(null)
-                }
-                .padding(8.dp),
-            textAlign = TextAlign.Center,
-            fontSize = 18.sp
-        )
-        Button(
-            onClick = {
-                if (steps > 0) {
-                    steps -= 1
-                    fields.stringList.removeAt(steps)
-                    selectedSLSymbols.removeAt(steps)
-                }
-            },
-            modifier = Modifier.padding(top = 4.dp),
-            colors = ButtonDefaults.buttonColors(
-                containerColor = getUIStyle.secondaryButtonColor(),
-                contentColor = getUIStyle.buttonTextColor()
-            )
-        ) {
-            Text("Remove Step")
+    val showKB by vm.showKatexKeyboard.collectAsStateWithLifecycle()
+    val selectedKB by vm.selectedKB.collectAsStateWithLifecycle()
+    var offset by remember { mutableStateOf(Offset.Zero) }
+    val context = LocalContext.current
+    val resetOffset by vm.resetOffset.collectAsStateWithLifecycle()
+    LaunchedEffect(resetOffset) {
+        if (resetOffset) {
+            offset = Offset(0f, 0f)
+            vm.resetDone()
         }
     }
-    LatexKeyboard(
-        value = fields.answer.value,
-        onValueChanged = { fields.answer.value = it },
-        labelStr = stringResource(R.string.answer),
-        modifier = Modifier.fillMaxWidth(),
-        focusRequester = focusRequester,
-        symbol = selectedASymbol,
-        onSymbol = { selectedASymbol = null }
-    )
+    Box {
+        if (showKB) {
+            KaTeXMenu(
+                modifier.fillMaxSize(), offset, onDismiss = { vm.toggleKeyboard() },
+                onOffset = { offset += it }, getUIStyle
+            ) { symbol ->
+                when (val sel = selectedKB) {
+                    is SelectedKeyboard.Question -> {
+                        selectedQSymbol = symbol
+                    }
+
+                    is SelectedKeyboard.Step -> {
+                        selectedSLSymbols[sel.index] = symbol
+                    }
+
+                    is SelectedKeyboard.Answer -> {
+                        selectedASymbol = symbol
+                    }
+
+                    else -> {
+                        showToastMessage(context, "Please select a text field first.")
+                        /* No Keyboard, Do Nothing */
+                    }
+                }
+
+            }
+        }
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            LatexKeyboard(
+                value = fields.question.value,
+                onValueChanged = { fields.question.value = it },
+                labelStr = stringResource(R.string.question),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(focusRequester)
+                    .onFocusChanged { focusState ->
+                        if (focusState.hasFocus) {
+                            vm.updateSelectedKB(SelectedKeyboard.Question)
+                            //lastSelectedKB = SelectedKeyboard.Question
+                            Log.d("AddCardVM", "Focused on Question")
+                        }
+                    }
+                    .focusable(),
+                focusRequester = focusRequester,
+                symbol = selectedQSymbol,
+                onSymbol = { selectedQSymbol = null }
+            )
+            if (steps == 0) {
+                Button(
+                    onClick = {
+                        fields.stringList.add(mutableStateOf(""))
+                        selectedSLSymbols.add(null)
+                        steps += 1
+                    }, modifier = Modifier
+                        .padding(8.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = getUIStyle.secondaryButtonColor(),
+                        contentColor = getUIStyle.buttonTextColor()
+                    ), enabled = true
+                ) {
+                    Text(
+                        text = "Add a step",
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            } else {
+                fields.stringList.forEachIndexed { index, string ->
+                    val indexedModifier = if (index == 0) {
+                        Modifier.padding(top = 5.dp, start = 0.5.dp, end = 0.5.dp, bottom = 1.dp)
+                    } else {
+                        Modifier.padding(1.dp)
+                    }
+                    LatexKeyboard(
+                        value = string.value,
+                        onValueChanged = { string.value = it },
+                        labelStr = "Step: ${index + 1}",
+                        modifier = indexedModifier
+                            .fillMaxWidth()
+                            .focusRequester(focusRequester)
+                            .onFocusChanged { focusState ->
+                                if (focusState.hasFocus) {
+                                    vm.updateSelectedKB(SelectedKeyboard.Step(index))
+                                    //lastSelectedKB = SelectedKeyboard.Step(index)
+                                    Log.d("AddCardVM", "Focused on Step #${index + 1}")
+                                }
+                            }
+                            .focusable(),
+                        focusRequester = focusRequester,
+                        symbol = selectedSLSymbols[index],
+                        onSymbol = { selectedSLSymbols[index] = null }
+                    )
+                }
+                Button(
+                    onClick = {
+                        fields.stringList.add(mutableStateOf(""))
+                        selectedSLSymbols.add(null)
+                        steps += 1
+                    }, modifier = Modifier
+                        .padding(8.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = getUIStyle.secondaryButtonColor(),
+                        contentColor = getUIStyle.buttonTextColor()
+                    ), enabled = true
+                ) {
+                    Text(
+                        text = "Add a step",
+                        textAlign = TextAlign.Center,
+                    )
+                }
+                Button(
+                    onClick = {
+                        if (steps > 0) {
+                            steps -= 1
+                            fields.stringList.removeAt(steps)
+                            selectedSLSymbols.removeAt(steps)
+                        }
+                    },
+                    modifier = Modifier.padding(top = 4.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = getUIStyle.secondaryButtonColor(),
+                        contentColor = getUIStyle.buttonTextColor()
+                    )
+                ) {
+                    Text("Remove Step")
+                }
+            }
+            LatexKeyboard(
+                value = fields.answer.value,
+                onValueChanged = { fields.answer.value = it },
+                labelStr = stringResource(R.string.answer),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(focusRequester)
+                    .onFocusChanged { focusState ->
+                        if (focusState.hasFocus) {
+                            vm.updateSelectedKB(SelectedKeyboard.Answer)
+                            //lastSelectedKB = SelectedKeyboard.Answer
+                            Log.d("AddCardVM", "Focused on Answer")
+                        } else {
+                            vm.resetSelectedKB()
+                            Log.d("AddCardVM", "Answer lost focus.")
+                        }
+                    }
+                    .focusable(),
+                focusRequester = focusRequester,
+                symbol = selectedASymbol,
+                onSymbol = { selectedASymbol = null }
+            )
+        }
+    }
 }


### PR DESCRIPTION
## Summary by Sourcery

Introduce a persistent, draggable KaTeX symbol palette for notation cards with full ViewModel integration to manage keyboard visibility, selection, and position while refactoring symbol utilities into a specialized package and renaming Supabase uploadDeck views to exportDeck for clarity.

New Features:
- Add draggable KaTeX symbol menu (KaTeXMenu) for notation input in add and edit card views
- Enable show/hide toggle and symbol selection for the KaTeX keyboard using ViewModel state
- Integrate tap and long-press gestures on a keyboard icon to toggle visibility and reset position of the notation keyboard

Bug Fixes:
- Ensure WebView instances in KaTeXMenu, KaTeXWebView, and DisplayCardDetails are destroyed to prevent resource leaks

Enhancements:
- Refactor all KaTeX and symbol utilities into a dedicated uiFunctions.katex package and update imports
- Enhance focus handling on LatexKeyboard fields to track and update the currently selected notation field

Chores:
- Rename Supabase view packages and files from uploadDeck to exportDeck to clarify export functionality